### PR TITLE
0408 1112405053 黃柏翰

### DIFF
--- a/weeks/week-05/solutions/1112405053/play_01_dev.py
+++ b/weeks/week-05/solutions/1112405053/play_01_dev.py
@@ -1,0 +1,189 @@
+"""Week 05 Phase 1 資料模型測試。
+
+此檔案使用 Python 內建 unittest，針對 Card / Deck / Hand / Player
+的核心行為設計測試案例。
+"""
+
+import unittest
+from importlib import import_module
+
+# 以動態方式載入，避免在不同執行目錄下出現匯入路徑問題。
+try:
+	_models = import_module("game.models")
+	Card = _models.Card
+	Deck = _models.Deck
+	Hand = _models.Hand
+	Player = _models.Player
+	MODELS_IMPORT_ERROR = None
+except ModuleNotFoundError as error:
+	Card = Deck = Hand = Player = None
+	MODELS_IMPORT_ERROR = error
+
+
+@unittest.skipIf(MODELS_IMPORT_ERROR is not None, "找不到 game.models，請在專案根目錄執行測試")
+class TestCard(unittest.TestCase):
+	"""測試 Card 類別：建立、顯示、比較與排序鍵。"""
+
+	def test_card_creation(self):
+		card = Card(rank=14, suit=3)
+		self.assertEqual(card.rank, 14)
+		self.assertEqual(card.suit, 3)
+
+	def test_card_repr_ace(self):
+		self.assertEqual(repr(Card(14, 3)), "♠A")
+
+	def test_card_repr_three(self):
+		self.assertEqual(repr(Card(3, 0)), "♣3")
+
+	def test_card_compare_suit(self):
+		self.assertGreater(Card(14, 3), Card(14, 2))  # ♠ > ♥
+
+	def test_card_compare_suit_2(self):
+		self.assertGreater(Card(14, 2), Card(14, 1))  # ♥ > ♦
+
+	def test_card_compare_suit_3(self):
+		self.assertGreater(Card(14, 1), Card(14, 0))  # ♦ > ♣
+
+	def test_card_compare_rank_2(self):
+		self.assertGreater(Card(15, 0), Card(14, 3))  # 2 > A
+
+	def test_card_compare_rank_a(self):
+		self.assertGreater(Card(14, 0), Card(13, 3))  # A > K
+
+	def test_card_compare_equal(self):
+		self.assertFalse(Card(14, 3) > Card(14, 3))
+
+	def test_card_sort_key(self):
+		self.assertEqual(Card(14, 3).to_sort_key(), (14, 3))
+
+
+@unittest.skipIf(MODELS_IMPORT_ERROR is not None, "找不到 game.models，請在專案根目錄執行測試")
+class TestDeck(unittest.TestCase):
+	"""測試 Deck 類別：牌組建立、洗牌與發牌。"""
+
+	def test_deck_has_52_cards(self):
+		deck = Deck()
+		self.assertEqual(len(deck.cards), 52)
+
+	def test_deck_all_unique(self):
+		deck = Deck()
+		self.assertEqual(len(set(deck.cards)), 52)
+
+	def test_deck_all_ranks(self):
+		deck = Deck()
+		ranks = {card.rank for card in deck.cards}
+		self.assertEqual(ranks, set(range(3, 16)))
+
+	def test_deck_all_suits(self):
+		deck = Deck()
+		suits = {card.suit for card in deck.cards}
+		self.assertEqual(suits, {0, 1, 2, 3})
+
+	def test_deck_shuffle(self):
+		deck = Deck()
+		before = list(deck.cards)
+		deck.shuffle()
+		after = deck.cards
+		# 洗牌後應仍為同一批牌，但順序通常會改變。
+		self.assertEqual(set(before), set(after))
+		self.assertNotEqual(before, after)
+
+	def test_deal_5_cards(self):
+		deck = Deck()
+		dealt = deck.deal(5)
+		self.assertEqual(len(dealt), 5)
+		self.assertEqual(len(deck.cards), 47)
+
+	def test_deal_multiple(self):
+		deck = Deck()
+		first = deck.deal(5)
+		second = deck.deal(3)
+		self.assertEqual(len(first), 5)
+		self.assertEqual(len(second), 3)
+		self.assertEqual(len(deck.cards), 44)
+
+	def test_deal_exceed(self):
+		deck = Deck()
+		dealt = deck.deal(60)
+		self.assertEqual(len(dealt), 52)
+		self.assertEqual(len(deck.cards), 0)
+
+
+@unittest.skipIf(MODELS_IMPORT_ERROR is not None, "找不到 game.models，請在專案根目錄執行測試")
+class TestHand(unittest.TestCase):
+	"""測試 Hand 類別：排序、搜尋與移除。"""
+
+	def test_hand_creation(self):
+		hand = Hand([Card(3, 0), Card(14, 3), Card(13, 2)])
+		self.assertEqual(len(hand), 3)
+
+	def test_hand_sort_desc(self):
+		hand = Hand([
+			Card(3, 0),   # ♣3
+			Card(14, 3),  # ♠A
+			Card(3, 3),   # ♠3
+			Card(13, 2),  # ♥K
+		])
+		hand.sort_desc()
+		self.assertEqual(hand, [Card(14, 3), Card(13, 2), Card(3, 3), Card(3, 0)])
+
+	def test_hand_find_3_clubs(self):
+		hand = Hand([Card(14, 3), Card(3, 0), Card(3, 1)])
+		self.assertEqual(hand.find_3_clubs(), Card(3, 0))
+
+	def test_hand_find_3_clubs_none(self):
+		hand = Hand([Card(14, 3), Card(3, 1)])
+		self.assertIsNone(hand.find_3_clubs())
+
+	def test_hand_remove(self):
+		c1 = Card(3, 0)
+		c2 = Card(14, 3)
+		c3 = Card(13, 2)
+		hand = Hand([c1, c2, c3])
+		hand.remove([c1, c2])
+		self.assertEqual(hand, [c3])
+
+	def test_hand_remove_not_found(self):
+		c1 = Card(3, 0)
+		c2 = Card(14, 3)
+		hand = Hand([c1, c2])
+		hand.remove([Card(9, 1)])
+		self.assertEqual(len(hand), 2)
+
+	def test_hand_iteration(self):
+		hand = Hand([Card(3, 0), Card(14, 3)])
+		self.assertEqual(len(list(hand)), 2)
+
+
+@unittest.skipIf(MODELS_IMPORT_ERROR is not None, "找不到 game.models，請在專案根目錄執行測試")
+class TestPlayer(unittest.TestCase):
+	"""測試 Player 類別：玩家初始化、拿牌與出牌。"""
+
+	def test_player_human(self):
+		player = Player("Player1", False)
+		self.assertEqual(player.name, "Player1")
+		self.assertFalse(player.is_ai)
+
+	def test_player_ai(self):
+		player = Player("AI_1", True)
+		self.assertEqual(player.name, "AI_1")
+		self.assertTrue(player.is_ai)
+
+	def test_player_take(self):
+		player = Player("Player1")
+		player.take_cards([Card(3, 0), Card(14, 3)])
+		self.assertEqual(len(player.hand), 2)
+
+	def test_player_play(self):
+		player = Player("Player1")
+		cards = [Card(3, 0), Card(14, 3), Card(13, 2)]
+		player.take_cards(cards)
+
+		played = player.play_cards([cards[0], cards[1]])
+
+		self.assertEqual(played, [cards[0], cards[1]])
+		self.assertEqual(player.hand, Hand([cards[2]]))
+
+
+if __name__ == "__main__":
+	unittest.main(verbosity=2)

--- a/weeks/week-05/solutions/1112405053/play_01_test.py
+++ b/weeks/week-05/solutions/1112405053/play_01_test.py
@@ -1,0 +1,189 @@
+"""Week 05 - Phase 1 資料模型單元測試。
+
+本檔案依據 p1-test.md 設計，使用 Python 內建 unittest 框架。
+測試目標：Card、Deck、Hand、Player 四個類別的核心行為。
+"""
+
+import unittest
+from importlib import import_module
+
+
+# 透過動態匯入降低執行目錄差異造成的路徑問題。
+try:
+	models = import_module("game.models")
+	Card = models.Card
+	Deck = models.Deck
+	Hand = models.Hand
+	Player = models.Player
+	IMPORT_ERROR = None
+except ModuleNotFoundError as error:
+	Card = Deck = Hand = Player = None
+	IMPORT_ERROR = error
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, "找不到 game.models，請在專案根目錄執行測試")
+class TestCard(unittest.TestCase):
+	"""Card 類別測試：建立、顯示、比較與排序鍵。"""
+
+	def test_card_creation(self):
+		card = Card(rank=14, suit=3)
+		self.assertEqual(card.rank, 14)
+		self.assertEqual(card.suit, 3)
+
+	def test_card_repr_ace(self):
+		self.assertEqual(repr(Card(14, 3)), "♠A")
+
+	def test_card_repr_three(self):
+		self.assertEqual(repr(Card(3, 0)), "♣3")
+
+	def test_card_compare_suit(self):
+		self.assertGreater(Card(14, 3), Card(14, 2))  # ♠ > ♥
+
+	def test_card_compare_suit_2(self):
+		self.assertGreater(Card(14, 2), Card(14, 1))  # ♥ > ♦
+
+	def test_card_compare_suit_3(self):
+		self.assertGreater(Card(14, 1), Card(14, 0))  # ♦ > ♣
+
+	def test_card_compare_rank_2(self):
+		self.assertGreater(Card(15, 0), Card(14, 3))  # 2 > A
+
+	def test_card_compare_rank_a(self):
+		self.assertGreater(Card(14, 0), Card(13, 3))  # A > K
+
+	def test_card_compare_equal(self):
+		self.assertFalse(Card(14, 3) > Card(14, 3))
+
+	def test_card_sort_key(self):
+		self.assertEqual(Card(14, 3).to_sort_key(), (14, 3))
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, "找不到 game.models，請在專案根目錄執行測試")
+class TestDeck(unittest.TestCase):
+	"""Deck 類別測試：52 張牌、洗牌、發牌。"""
+
+	def test_deck_has_52_cards(self):
+		deck = Deck()
+		self.assertEqual(len(deck.cards), 52)
+
+	def test_deck_all_unique(self):
+		deck = Deck()
+		self.assertEqual(len(set(deck.cards)), 52)
+
+	def test_deck_all_ranks(self):
+		deck = Deck()
+		ranks = {card.rank for card in deck.cards}
+		# 依遊戲規則應包含 3~15（15 代表 2）。
+		self.assertEqual(ranks, set(range(3, 16)))
+
+	def test_deck_all_suits(self):
+		deck = Deck()
+		suits = {card.suit for card in deck.cards}
+		self.assertEqual(suits, {0, 1, 2, 3})
+
+	def test_deck_shuffle(self):
+		deck = Deck()
+		before = list(deck.cards)
+		deck.shuffle()
+		after = deck.cards
+		# 洗牌後應維持同一組牌，且順序通常會改變。
+		self.assertEqual(set(before), set(after))
+		self.assertNotEqual(before, after)
+
+	def test_deal_5_cards(self):
+		deck = Deck()
+		dealt = deck.deal(5)
+		self.assertEqual(len(dealt), 5)
+		self.assertEqual(len(deck.cards), 47)
+
+	def test_deal_multiple(self):
+		deck = Deck()
+		first = deck.deal(5)
+		second = deck.deal(3)
+		self.assertEqual(len(first), 5)
+		self.assertEqual(len(second), 3)
+		self.assertEqual(len(deck.cards), 44)
+
+	def test_deal_exceed(self):
+		deck = Deck()
+		dealt = deck.deal(60)
+		self.assertEqual(len(dealt), 52)
+		self.assertEqual(len(deck.cards), 0)
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, "找不到 game.models，請在專案根目錄執行測試")
+class TestHand(unittest.TestCase):
+	"""Hand 類別測試：初始化、排序、查找、移除。"""
+
+	def test_hand_creation(self):
+		hand = Hand([Card(3, 0), Card(14, 3), Card(13, 2)])
+		self.assertEqual(len(hand), 3)
+
+	def test_hand_sort_desc(self):
+		hand = Hand([
+			Card(3, 0),   # ♣3
+			Card(14, 3),  # ♠A
+			Card(3, 3),   # ♠3
+			Card(13, 2),  # ♥K
+		])
+		hand.sort_desc()
+		self.assertEqual(hand, [Card(14, 3), Card(13, 2), Card(3, 3), Card(3, 0)])
+
+	def test_hand_find_3_clubs(self):
+		hand = Hand([Card(14, 3), Card(3, 0), Card(3, 1)])
+		self.assertEqual(hand.find_3_clubs(), Card(3, 0))
+
+	def test_hand_find_3_clubs_none(self):
+		hand = Hand([Card(14, 3), Card(3, 1)])
+		self.assertIsNone(hand.find_3_clubs())
+
+	def test_hand_remove(self):
+		c1 = Card(3, 0)
+		c2 = Card(14, 3)
+		c3 = Card(13, 2)
+		hand = Hand([c1, c2, c3])
+		hand.remove([c1, c2])
+		self.assertEqual(hand, [c3])
+
+	def test_hand_remove_not_found(self):
+		hand = Hand([Card(3, 0), Card(14, 3)])
+		hand.remove([Card(9, 1)])
+		self.assertEqual(len(hand), 2)
+
+	def test_hand_iteration(self):
+		hand = Hand([Card(3, 0), Card(14, 3)])
+		self.assertEqual(len(list(hand)), 2)
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, "找不到 game.models，請在專案根目錄執行測試")
+class TestPlayer(unittest.TestCase):
+	"""Player 類別測試：玩家屬性、拿牌、出牌。"""
+
+	def test_player_human(self):
+		player = Player("Player1", False)
+		self.assertEqual(player.name, "Player1")
+		self.assertFalse(player.is_ai)
+
+	def test_player_ai(self):
+		player = Player("AI_1", True)
+		self.assertEqual(player.name, "AI_1")
+		self.assertTrue(player.is_ai)
+
+	def test_player_take(self):
+		player = Player("Player1")
+		player.take_cards([Card(3, 0), Card(14, 3)])
+		self.assertEqual(len(player.hand), 2)
+
+	def test_player_play(self):
+		player = Player("Player1")
+		cards = [Card(3, 0), Card(14, 3), Card(13, 2)]
+		player.take_cards(cards)
+
+		played = player.play_cards([cards[0], cards[1]])
+
+		self.assertEqual(played, [cards[0], cards[1]])
+		self.assertEqual(player.hand, Hand([cards[2]]))
+
+
+if __name__ == "__main__":
+	unittest.main(verbosity=2)

--- a/weeks/week-05/solutions/1112405053/play_02_dev.py
+++ b/weeks/week-05/solutions/1112405053/play_02_dev.py
@@ -1,0 +1,167 @@
+"""Week 05 - Phase 2 牌型分類單元測試。
+
+依據 p2-dev.md 與 p2-test.md 設計，測試目標包含：
+1. CardType 列舉值
+2. HandClassifier.classify 牌型分類
+3. HandClassifier.compare 牌型比較
+4. HandClassifier.can_play 出牌合法性
+"""
+
+import unittest
+from importlib import import_module
+
+
+# 以動態匯入降低路徑差異帶來的執行問題。
+try:
+	models = import_module("game.models")
+	classifier = import_module("game.classifier")
+	Card = models.Card
+	CardType = classifier.CardType
+	HandClassifier = classifier.HandClassifier
+	IMPORT_ERROR = None
+except ModuleNotFoundError as error:
+	Card = CardType = HandClassifier = None
+	IMPORT_ERROR = error
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, "找不到 game.models 或 game.classifier，請在專案根目錄執行測試")
+class TestCardType(unittest.TestCase):
+	"""測試 CardType 列舉值是否符合規格。"""
+
+	def test_cardtype_values(self):
+		self.assertEqual(CardType.SINGLE.value, 1)
+		self.assertEqual(CardType.PAIR.value, 2)
+		self.assertEqual(CardType.TRIPLE.value, 3)
+		self.assertEqual(CardType.STRAIGHT.value, 4)
+		self.assertEqual(CardType.FLUSH.value, 5)
+		self.assertEqual(CardType.FULL_HOUSE.value, 6)
+		self.assertEqual(CardType.FOUR_OF_A_KIND.value, 7)
+		self.assertEqual(CardType.STRAIGHT_FLUSH.value, 8)
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, "找不到 game.models 或 game.classifier，請在專案根目錄執行測試")
+class TestClassify(unittest.TestCase):
+	"""測試 HandClassifier.classify 的牌型分類。"""
+
+	def test_classify_single_ace(self):
+		result = HandClassifier.classify([Card(14, 3)])
+		self.assertEqual(result, (CardType.SINGLE, 14, 3))
+
+	def test_classify_single_two(self):
+		result = HandClassifier.classify([Card(15, 0)])
+		self.assertEqual(result, (CardType.SINGLE, 15, 0))
+
+	def test_classify_single_three(self):
+		result = HandClassifier.classify([Card(3, 0)])
+		self.assertEqual(result, (CardType.SINGLE, 3, 0))
+
+	def test_classify_pair(self):
+		result = HandClassifier.classify([Card(14, 3), Card(14, 2)])
+		self.assertEqual(result, (CardType.PAIR, 14, 0))
+
+	def test_classify_pair_diff_rank(self):
+		result = HandClassifier.classify([Card(14, 3), Card(13, 3)])
+		self.assertIsNone(result)
+
+	def test_classify_pair_from_three(self):
+		result = HandClassifier.classify([Card(14, 3), Card(14, 2)])
+		self.assertEqual(result, (CardType.PAIR, 14, 0))
+
+	def test_classify_triple(self):
+		result = HandClassifier.classify([Card(14, 3), Card(14, 2), Card(14, 1)])
+		self.assertEqual(result, (CardType.TRIPLE, 14, 0))
+
+	def test_classify_triple_not_enough(self):
+		result = HandClassifier.classify([Card(14, 3), Card(14, 2)])
+		self.assertIsNone(result)
+
+	def test_classify_straight(self):
+		cards = [Card(3, 0), Card(4, 1), Card(5, 2), Card(6, 3), Card(7, 0)]
+		result = HandClassifier.classify(cards)
+		self.assertEqual(result, (CardType.STRAIGHT, 7, 0))
+
+	def test_classify_straight_ace_low(self):
+		cards = [Card(14, 0), Card(15, 1), Card(3, 2), Card(4, 3), Card(5, 0)]
+		result = HandClassifier.classify(cards)
+		self.assertEqual(result, (CardType.STRAIGHT, 5, 0))
+
+	def test_classify_flush(self):
+		cards = [Card(3, 0), Card(5, 0), Card(7, 0), Card(9, 0), Card(11, 0)]
+		result = HandClassifier.classify(cards)
+		self.assertEqual(result, (CardType.FLUSH, 11, 0))
+
+	def test_classify_full_house(self):
+		cards = [Card(14, 3), Card(14, 2), Card(14, 1), Card(15, 0), Card(15, 1)]
+		result = HandClassifier.classify(cards)
+		self.assertEqual(result, (CardType.FULL_HOUSE, 14, 0))
+
+	def test_classify_four_of_a_kind(self):
+		cards = [Card(14, 3), Card(14, 2), Card(14, 1), Card(14, 0), Card(3, 1)]
+		result = HandClassifier.classify(cards)
+		self.assertEqual(result, (CardType.FOUR_OF_A_KIND, 14, 0))
+
+	def test_classify_straight_flush(self):
+		cards = [Card(3, 0), Card(4, 0), Card(5, 0), Card(6, 0), Card(7, 0)]
+		result = HandClassifier.classify(cards)
+		self.assertEqual(result, (CardType.STRAIGHT_FLUSH, 7, 0))
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, "找不到 game.models 或 game.classifier，請在專案根目錄執行測試")
+class TestCompare(unittest.TestCase):
+	"""測試 HandClassifier.compare 的牌型大小比較。"""
+
+	def test_compare_single_rank(self):
+		self.assertEqual(HandClassifier.compare([Card(14, 3)], [Card(13, 3)]), 1)
+
+	def test_compare_single_suit(self):
+		self.assertEqual(HandClassifier.compare([Card(14, 3)], [Card(14, 2)]), 1)
+
+	def test_compare_pair_rank(self):
+		play1 = [Card(14, 3), Card(14, 2)]
+		play2 = [Card(13, 3), Card(13, 2)]
+		self.assertEqual(HandClassifier.compare(play1, play2), 1)
+
+	def test_compare_pair_suit(self):
+		play1 = [Card(14, 3), Card(14, 2)]
+		play2 = [Card(14, 1), Card(14, 0)]
+		self.assertEqual(HandClassifier.compare(play1, play2), 1)
+
+	def test_compare_different_type(self):
+		pair_play = [Card(6, 3), Card(6, 1)]
+		single_play = [Card(15, 0)]
+		self.assertEqual(HandClassifier.compare(pair_play, single_play), 1)
+
+	def test_compare_flush_vs_straight(self):
+		flush_play = [Card(3, 0), Card(5, 0), Card(7, 0), Card(9, 0), Card(11, 0)]
+		straight_play = [Card(3, 0), Card(4, 1), Card(5, 2), Card(6, 3), Card(7, 0)]
+		self.assertEqual(HandClassifier.compare(flush_play, straight_play), 1)
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, "找不到 game.models 或 game.classifier，請在專案根目錄執行測試")
+class TestCanPlay(unittest.TestCase):
+	"""測試 HandClassifier.can_play 的合法性判斷。"""
+
+	def test_can_play_first_3clubs(self):
+		self.assertTrue(HandClassifier.can_play(None, [Card(3, 0)]))
+
+	def test_can_play_first_not_3clubs(self):
+		self.assertFalse(HandClassifier.can_play(None, [Card(14, 3)]))
+
+	def test_can_play_same_type(self):
+		last_play = [Card(5, 3), Card(5, 2)]
+		new_play = [Card(6, 3), Card(6, 2)]
+		self.assertTrue(HandClassifier.can_play(last_play, new_play))
+
+	def test_can_play_diff_type(self):
+		last_play = [Card(5, 3), Card(5, 2)]
+		new_play = [Card(6, 3)]
+		self.assertFalse(HandClassifier.can_play(last_play, new_play))
+
+	def test_can_play_not_stronger(self):
+		last_play = [Card(10, 3), Card(10, 2)]
+		new_play = [Card(5, 3), Card(5, 2)]
+		self.assertFalse(HandClassifier.can_play(last_play, new_play))
+
+
+if __name__ == "__main__":
+	unittest.main(verbosity=2)

--- a/weeks/week-05/solutions/1112405053/play_02_test.py
+++ b/weeks/week-05/solutions/1112405053/play_02_test.py
@@ -1,0 +1,160 @@
+"""Week 05 - Phase 2 牌型分類單元測試。
+
+本檔案依據 p2-test.md 設計，使用 Python 內建 unittest。
+測試範圍：CardType、HandClassifier.classify、compare、can_play。
+"""
+
+import unittest
+from importlib import import_module
+
+
+# 以動態匯入處理不同執行路徑下的模組解析問題。
+try:
+	models = import_module("game.models")
+	classifier = import_module("game.classifier")
+	Card = models.Card
+	CardType = classifier.CardType
+	HandClassifier = classifier.HandClassifier
+	IMPORT_ERROR = None
+except ModuleNotFoundError as error:
+	Card = CardType = HandClassifier = None
+	IMPORT_ERROR = error
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, "找不到 game.models 或 game.classifier，請在專案根目錄執行測試")
+class TestCardType(unittest.TestCase):
+	"""測試 CardType 列舉值是否符合題目定義。"""
+
+	def test_cardtype_values(self):
+		self.assertEqual(CardType.SINGLE.value, 1)
+		self.assertEqual(CardType.PAIR.value, 2)
+		self.assertEqual(CardType.TRIPLE.value, 3)
+		self.assertEqual(CardType.STRAIGHT.value, 4)
+		self.assertEqual(CardType.FLUSH.value, 5)
+		self.assertEqual(CardType.FULL_HOUSE.value, 6)
+		self.assertEqual(CardType.FOUR_OF_A_KIND.value, 7)
+		self.assertEqual(CardType.STRAIGHT_FLUSH.value, 8)
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, "找不到 game.models 或 game.classifier，請在專案根目錄執行測試")
+class TestClassify(unittest.TestCase):
+	"""測試 HandClassifier.classify 的牌型分類結果。"""
+
+	def test_classify_single_ace(self):
+		self.assertEqual(HandClassifier.classify([Card(14, 3)]), (CardType.SINGLE, 14, 3))
+
+	def test_classify_single_two(self):
+		self.assertEqual(HandClassifier.classify([Card(15, 0)]), (CardType.SINGLE, 15, 0))
+
+	def test_classify_single_three(self):
+		self.assertEqual(HandClassifier.classify([Card(3, 0)]), (CardType.SINGLE, 3, 0))
+
+	def test_classify_pair(self):
+		self.assertEqual(
+			HandClassifier.classify([Card(14, 3), Card(14, 2)]),
+			(CardType.PAIR, 14, 0),
+		)
+
+	def test_classify_pair_diff_rank(self):
+		self.assertIsNone(HandClassifier.classify([Card(14, 3), Card(13, 3)]))
+
+	def test_classify_pair_from_three(self):
+		# 由三條中任取兩張，仍應視為合法對子。
+		self.assertEqual(
+			HandClassifier.classify([Card(14, 3), Card(14, 2)]),
+			(CardType.PAIR, 14, 0),
+		)
+
+	def test_classify_triple(self):
+		self.assertEqual(
+			HandClassifier.classify([Card(14, 3), Card(14, 2), Card(14, 1)]),
+			(CardType.TRIPLE, 14, 0),
+		)
+
+	def test_classify_triple_not_enough(self):
+		self.assertIsNone(HandClassifier.classify([Card(14, 3), Card(14, 2)]))
+
+	def test_classify_straight(self):
+		cards = [Card(3, 0), Card(4, 1), Card(5, 2), Card(6, 3), Card(7, 0)]
+		self.assertEqual(HandClassifier.classify(cards), (CardType.STRAIGHT, 7, 0))
+
+	def test_classify_straight_ace_low(self):
+		cards = [Card(14, 0), Card(15, 1), Card(3, 2), Card(4, 3), Card(5, 0)]
+		self.assertEqual(HandClassifier.classify(cards), (CardType.STRAIGHT, 5, 0))
+
+	def test_classify_flush(self):
+		cards = [Card(3, 0), Card(5, 0), Card(7, 0), Card(9, 0), Card(11, 0)]
+		self.assertEqual(HandClassifier.classify(cards), (CardType.FLUSH, 11, 0))
+
+	def test_classify_full_house(self):
+		cards = [Card(14, 3), Card(14, 2), Card(14, 1), Card(15, 0), Card(15, 1)]
+		self.assertEqual(HandClassifier.classify(cards), (CardType.FULL_HOUSE, 14, 0))
+
+	def test_classify_four_of_a_kind(self):
+		cards = [Card(14, 3), Card(14, 2), Card(14, 1), Card(14, 0), Card(3, 1)]
+		self.assertEqual(HandClassifier.classify(cards), (CardType.FOUR_OF_A_KIND, 14, 0))
+
+	def test_classify_straight_flush(self):
+		cards = [Card(3, 0), Card(4, 0), Card(5, 0), Card(6, 0), Card(7, 0)]
+		self.assertEqual(HandClassifier.classify(cards), (CardType.STRAIGHT_FLUSH, 7, 0))
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, "找不到 game.models 或 game.classifier，請在專案根目錄執行測試")
+class TestCompare(unittest.TestCase):
+	"""測試 HandClassifier.compare 的大小比較邏輯。"""
+
+	def test_compare_single_rank(self):
+		self.assertEqual(HandClassifier.compare([Card(14, 3)], [Card(13, 3)]), 1)
+
+	def test_compare_single_suit(self):
+		self.assertEqual(HandClassifier.compare([Card(14, 3)], [Card(14, 2)]), 1)
+
+	def test_compare_pair_rank(self):
+		play1 = [Card(14, 3), Card(14, 2)]
+		play2 = [Card(13, 3), Card(13, 2)]
+		self.assertEqual(HandClassifier.compare(play1, play2), 1)
+
+	def test_compare_pair_suit(self):
+		play1 = [Card(14, 3), Card(14, 2)]
+		play2 = [Card(14, 1), Card(14, 0)]
+		self.assertEqual(HandClassifier.compare(play1, play2), 1)
+
+	def test_compare_different_type(self):
+		pair_play = [Card(6, 3), Card(6, 1)]
+		single_play = [Card(15, 0)]
+		self.assertEqual(HandClassifier.compare(pair_play, single_play), 1)
+
+	def test_compare_flush_vs_straight(self):
+		flush_play = [Card(3, 0), Card(5, 0), Card(7, 0), Card(9, 0), Card(11, 0)]
+		straight_play = [Card(3, 0), Card(4, 1), Card(5, 2), Card(6, 3), Card(7, 0)]
+		self.assertEqual(HandClassifier.compare(flush_play, straight_play), 1)
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, "找不到 game.models 或 game.classifier，請在專案根目錄執行測試")
+class TestCanPlay(unittest.TestCase):
+	"""測試 HandClassifier.can_play 的出牌合法性。"""
+
+	def test_can_play_first_3clubs(self):
+		self.assertTrue(HandClassifier.can_play(None, [Card(3, 0)]))
+
+	def test_can_play_first_not_3clubs(self):
+		self.assertFalse(HandClassifier.can_play(None, [Card(14, 3)]))
+
+	def test_can_play_same_type(self):
+		last_play = [Card(5, 3), Card(5, 2)]
+		new_play = [Card(6, 3), Card(6, 2)]
+		self.assertTrue(HandClassifier.can_play(last_play, new_play))
+
+	def test_can_play_diff_type(self):
+		last_play = [Card(5, 3), Card(5, 2)]
+		new_play = [Card(6, 3)]
+		self.assertFalse(HandClassifier.can_play(last_play, new_play))
+
+	def test_can_play_not_stronger(self):
+		last_play = [Card(10, 3), Card(10, 2)]
+		new_play = [Card(5, 3), Card(5, 2)]
+		self.assertFalse(HandClassifier.can_play(last_play, new_play))
+
+
+if __name__ == "__main__":
+	unittest.main(verbosity=2)

--- a/weeks/week-05/solutions/1112405053/play_03_test.py
+++ b/weeks/week-05/solutions/1112405053/play_03_test.py
@@ -1,0 +1,150 @@
+"""Week 05 - Phase 3 牌型搜尋單元測試。
+
+本檔案依據 p3-test.md 與 p3-dev.md 設計，
+測試目標為 HandFinder 的牌型搜尋與合法出牌搜尋。
+"""
+
+import unittest
+from importlib import import_module
+
+
+# 動態匯入可避免不同執行目錄造成的 import 路徑問題。
+try:
+	models = import_module("game.models")
+	finder_mod = import_module("game.finder")
+	classifier_mod = import_module("game.classifier")
+	Card = models.Card
+	Hand = models.Hand
+	HandFinder = finder_mod.HandFinder
+	HandClassifier = classifier_mod.HandClassifier
+	CardType = classifier_mod.CardType
+	IMPORT_ERROR = None
+except ModuleNotFoundError as error:
+	Card = Hand = HandFinder = HandClassifier = CardType = None
+	IMPORT_ERROR = error
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, "找不到 game 模組，請在專案根目錄執行測試")
+class TestFindSingles(unittest.TestCase):
+	"""測試單張搜尋。"""
+
+	def test_find_singles(self):
+		hand = Hand([Card(14, 3), Card(13, 2), Card(3, 0)])
+		singles = HandFinder.find_singles(hand)
+		self.assertEqual(len(singles), 3)
+		self.assertTrue(all(len(play) == 1 for play in singles))
+
+	def test_find_singles_empty(self):
+		hand = Hand([])
+		singles = HandFinder.find_singles(hand)
+		self.assertEqual(singles, [])
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, "找不到 game 模組，請在專案根目錄執行測試")
+class TestFindPairs(unittest.TestCase):
+	"""測試對子搜尋。"""
+
+	def test_find_pairs_one(self):
+		hand = Hand([Card(14, 3), Card(14, 2), Card(3, 0)])
+		pairs = HandFinder.find_pairs(hand)
+		self.assertEqual(len(pairs), 1)
+		self.assertEqual([c.rank for c in pairs[0]], [14, 14])
+
+	def test_find_pairs_two(self):
+		hand = Hand([Card(14, 3), Card(14, 2), Card(13, 3), Card(13, 0)])
+		pairs = HandFinder.find_pairs(hand)
+		self.assertEqual(len(pairs), 2)
+		self.assertTrue(all(len(play) == 2 for play in pairs))
+
+	def test_find_pairs_none(self):
+		hand = Hand([Card(14, 3), Card(13, 2), Card(3, 0)])
+		pairs = HandFinder.find_pairs(hand)
+		self.assertEqual(pairs, [])
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, "找不到 game 模組，請在專案根目錄執行測試")
+class TestFindTriples(unittest.TestCase):
+	"""測試三條搜尋。"""
+
+	def test_find_triples_one(self):
+		hand = Hand([Card(14, 3), Card(14, 2), Card(14, 1), Card(3, 0)])
+		triples = HandFinder.find_triples(hand)
+		self.assertEqual(len(triples), 1)
+		self.assertEqual([c.rank for c in triples[0]], [14, 14, 14])
+
+	def test_find_triples_with_extra(self):
+		# AAA + KK 應只產生 1 組三條。
+		hand = Hand([Card(14, 3), Card(14, 2), Card(14, 1), Card(13, 3), Card(13, 2)])
+		triples = HandFinder.find_triples(hand)
+		self.assertEqual(len(triples), 1)
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, "找不到 game 模組，請在專案根目錄執行測試")
+class TestFindFives(unittest.TestCase):
+	"""測試五張牌型搜尋。"""
+
+	def _contains_type(self, plays, target_type):
+		# 將每一組五張牌交給 HandClassifier 判定，確認是否含指定牌型。
+		for play in plays:
+			classified = HandClassifier.classify(play)
+			if classified is not None and classified[0] == target_type:
+				return True
+		return False
+
+	def test_find_straight(self):
+		hand = Hand([Card(3, 0), Card(4, 1), Card(5, 2), Card(6, 3), Card(7, 0), Card(11, 2)])
+		fives = HandFinder.find_fives(hand)
+		self.assertTrue(self._contains_type(fives, CardType.STRAIGHT))
+
+	def test_find_flush(self):
+		hand = Hand([Card(3, 0), Card(5, 0), Card(7, 0), Card(9, 0), Card(11, 0), Card(4, 1)])
+		fives = HandFinder.find_fives(hand)
+		self.assertTrue(self._contains_type(fives, CardType.FLUSH))
+
+	def test_find_full_house(self):
+		hand = Hand([Card(14, 3), Card(14, 2), Card(14, 1), Card(13, 3), Card(13, 2), Card(4, 0)])
+		fives = HandFinder.find_fives(hand)
+		self.assertTrue(self._contains_type(fives, CardType.FULL_HOUSE))
+
+	def test_find_four_of_a_kind(self):
+		hand = Hand([Card(14, 3), Card(14, 2), Card(14, 1), Card(14, 0), Card(3, 1), Card(5, 2)])
+		fives = HandFinder.find_fives(hand)
+		self.assertTrue(self._contains_type(fives, CardType.FOUR_OF_A_KIND))
+
+	def test_find_straight_flush(self):
+		hand = Hand([Card(3, 0), Card(4, 0), Card(5, 0), Card(6, 0), Card(7, 0), Card(10, 2)])
+		fives = HandFinder.find_fives(hand)
+		self.assertTrue(self._contains_type(fives, CardType.STRAIGHT_FLUSH))
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, "找不到 game 模組，請在專案根目錄執行測試")
+class TestGetAllValidPlays(unittest.TestCase):
+	"""測試合法出牌搜尋。"""
+
+	def test_first_turn(self):
+		hand = Hand([Card(3, 0), Card(14, 3), Card(13, 2)])
+		plays = HandFinder.get_all_valid_plays(hand, None)
+		# 第一手必須含 3♣，此處至少應包含 [3♣]。
+		self.assertIn([Card(3, 0)], plays)
+
+	def test_with_last_single(self):
+		hand = Hand([Card(6, 0), Card(7, 1), Card(10, 2), Card(11, 3)])
+		last_play = [Card(5, 2)]
+		plays = HandFinder.get_all_valid_plays(hand, last_play)
+		self.assertTrue(all(len(play) == 1 for play in plays))
+
+	def test_with_last_pair(self):
+		hand = Hand([Card(6, 3), Card(6, 2), Card(8, 3), Card(9, 2)])
+		last_play = [Card(5, 3), Card(5, 2)]
+		plays = HandFinder.get_all_valid_plays(hand, last_play)
+		self.assertTrue(all(len(play) == 2 for play in plays))
+
+	def test_no_valid(self):
+		hand = Hand([Card(3, 1), Card(4, 2), Card(7, 0), Card(9, 3)])
+		last_play = [Card(15, 3)]
+		plays = HandFinder.get_all_valid_plays(hand, last_play)
+		self.assertEqual(plays, [])
+
+
+if __name__ == "__main__":
+	unittest.main(verbosity=2)

--- a/weeks/week-07/solutions/1112405053/test_10062.py
+++ b/weeks/week-07/solutions/1112405053/test_10062.py
@@ -3,7 +3,7 @@ import sys
 
 class FenwickTree:
 	def __init__(self, n: int) -> None:
-		self.n = n
+		self.n = n 
 		self.bit = [0] * (n + 1)
 
 	def add(self, idx: int, delta: int) -> None:

--- a/weeks/week-07/solutions/1112405053/test_10062.py
+++ b/weeks/week-07/solutions/1112405053/test_10062.py
@@ -1,0 +1,52 @@
+import sys
+
+
+class FenwickTree:
+	def __init__(self, n: int) -> None:
+		self.n = n
+		self.bit = [0] * (n + 1)
+
+	def add(self, idx: int, delta: int) -> None:
+		while idx <= self.n:
+			self.bit[idx] += delta
+			idx += idx & -idx
+
+	def kth(self, k: int) -> int:
+		# 找到前綴和大於等於 k 的最小索引。
+		idx = 0
+		step = 1 << (self.n.bit_length() - 1)
+		while step:
+			nxt = idx + step
+			if nxt <= self.n and self.bit[nxt] < k:
+				k -= self.bit[nxt]
+				idx = nxt
+			step >>= 1
+		return idx + 1
+
+
+def solve() -> None:
+	data = list(map(int, sys.stdin.buffer.read().split()))
+	if not data:
+		return
+
+	n = data[0]
+	smaller_before = [0] * (n + 1)
+	for i in range(2, n + 1):
+		smaller_before[i] = data[i - 1]
+
+	fw = FenwickTree(n)
+	for brand in range(1, n + 1):
+		fw.add(brand, 1)
+
+	ans = [0] * (n + 1)
+	for pos in range(n, 0, -1):
+		k = smaller_before[pos] + 1
+		brand = fw.kth(k)
+		ans[pos] = brand
+		fw.add(brand, -1)
+
+	sys.stdout.write("\n".join(map(str, ans[1:])))
+
+
+if __name__ == "__main__":
+	solve()


### PR DESCRIPTION
這個 Pull Request 為卡牌遊戲專案的資料模型與手牌判定/規則邏輯新增了完整的單元測試。總共加入 4 個新的測試檔案，分別針對核心類別與規則判定進行驗證，測試使用 Python 內建的 unittest 框架，目標是確保遊戲模型與出牌規則邏輯的正確性與穩健性。

主要變更重點如下：

一、資料模型單元測試
新增 play_01_test.py 與 play_01_dev.py，用來測試核心資料模型：Card、Deck、Hand、Player。
測試涵蓋：
物件建立與字串表示（__repr__ / __str__ 等）
物件比較行為（例如卡牌大小/排序邏輯）
牌堆操作（洗牌 shuffle、發牌 deal）
手牌操作（排序 sort、查找 find、移除 remove）
玩家動作（拿牌 take、出牌 play）
參考：[[1]](https://github.com/copilot/c/b7688869-23d5-4680-9f35-b14678b2eca9) [[2]](https://github.com/copilot/c/b7688869-23d5-4680-9f35-b14678b2eca9)
二、手牌分類與遊戲規則邏輯單元測試
新增 play_02_test.py 與 play_02_dev.py，用來測試手牌分類與規則判定邏輯。
測試涵蓋：
CardType 列舉值是否正確
HandClassifier.classify：手牌型別判定是否正確
HandClassifier.compare：不同手牌之間比較/勝負判定是否正確
HandClassifier.can_play：出牌是否合法的規則檢查
參考：[[1]](https://github.com/copilot/c/b7688869-23d5-4680-9f35-b14678b2eca9) [[2]](https://github.com/copilot/c/b7688869-23d5-4680-9f35-b14678b2eca9)
三、測試穩健性與匯入（Import）處理
所有測試檔案都使用動態匯入（dynamic imports）與 unittest.skipIf：
當相依模組缺失、或執行目錄不正確時，能以跳過測試的方式「優雅失敗」
提升開發者體驗與在不同環境下執行測試的可攜性
參考：[[1]](https://github.com/copilot/c/b7688869-23d5-4680-9f35-b14678b2eca9) [[2]](https://github.com/copilot/c/b7688869-23d5-4680-9f35-b14678b2eca9) [[3]](https://github.com/copilot/c/b7688869-23d5-4680-9f35-b14678b2eca9) [[4]](https://github.com/copilot/c/b7688869-23d5-4680-9f35-b14678b2eca9)
四、文件化與結構安排
每個測試檔案皆包含清楚的（中文）docstring，說明測試範圍與目的。
測試案例依照類別/功能分段整理，提升可讀性、可維護性與擴充性。
參考：[[1]](https://github.com/copilot/c/b7688869-23d5-4680-9f35-b14678b2eca9) [[2]](https://github.com/copilot/c/b7688869-23d5-4680-9f35-b14678b2eca9) [[3]](https://github.com/copilot/c/b7688869-23d5-4680-9f35-b14678b2eca9) [[4]](https://github.com/copilot/c/b7688869-23d5-4680-9f35-b14678b2eca9)