### PR TITLE
0429-1112405053-黃柏翰

### DIFF
--- a/weeks/week-10/solutions/1112405053/10226_EASY.py
+++ b/weeks/week-10/solutions/1112405053/10226_EASY.py
@@ -1,0 +1,48 @@
+import sys
+
+
+def dfs(n, pos, used, cur, forb, prev, out):
+    if pos == n:
+        s = ''.join(cur)
+        l = 0
+        m = min(len(prev[0]), len(s))
+        while l < m and prev[0][l] == s[l]:
+            l += 1
+        out.append(s[l:])
+        prev[0] = s
+        return
+    for p in range(n):
+        if not (used >> p) & 1 and (pos + 1) not in forb[p]:
+            cur.append(chr(65 + p))
+            dfs(n, pos + 1, used | (1 << p), cur, forb, prev, out)
+            cur.pop()
+
+
+def main():
+    data = sys.stdin.read().split()
+    if not data:
+        return
+    it = iter(data)
+    out = []
+    while True:
+        try:
+            n = int(next(it))
+        except StopIteration:
+            break
+        forb = [set() for _ in range(n)]
+        for i in range(n):
+            while True:
+                v = int(next(it))
+                if v == 0:
+                    break
+                forb[i].add(v)
+        prev = ['']
+        dfs(n, 0, 0, [], forb, prev, out)
+        out.append('')
+    if out and out[-1] == '':
+        out.pop()
+    sys.stdout.write('\n'.join(out))
+
+
+if __name__ == '__main__':
+    main()

--- a/weeks/week-10/solutions/1112405053/10226_ME.py
+++ b/weeks/week-10/solutions/1112405053/10226_ME.py
@@ -1,0 +1,67 @@
+
+import sys
+
+
+def dfs(N, pos, used_mask, cur, forbidden, emit):
+	if pos == N:
+		emit(''.join(cur))
+		return
+	for p in range(N):
+		if not (used_mask >> p) & 1:
+			# person p (0..N-1) placed at position pos+1
+			if (pos + 1) in forbidden[p]:
+				continue
+			cur.append(chr(ord('A') + p))
+			dfs(N, pos + 1, used_mask | (1 << p), cur, forbidden, emit)
+			cur.pop()
+
+
+def solve(tokens):
+	it = iter(tokens)
+	out_lines = []
+	first_case = True
+	while True:
+		try:
+			N = int(next(it))
+		except StopIteration:
+			break
+		forbidden = [set() for _ in range(N)]
+		for i in range(N):
+			while True:
+				v = int(next(it))
+				if v == 0:
+					break
+				forbidden[i].add(v)
+
+		prev = ''
+
+		def emit(s):
+			nonlocal prev
+			# compute common prefix length
+			l = 0
+			m = min(len(prev), len(s))
+			while l < m and prev[l] == s[l]:
+				l += 1
+			out_lines.append(s[l:])
+			prev = s
+
+		dfs(N, 0, 0, [], forbidden, emit)
+
+		# blank line between cases
+		out_lines.append('')
+
+	# remove trailing blank line if present
+	if out_lines and out_lines[-1] == '':
+		out_lines.pop()
+	return '\n'.join(out_lines)
+
+
+def main():
+	data = sys.stdin.read().strip().split()
+	if not data:
+		return
+	print(solve(data))
+
+
+if __name__ == '__main__':
+	main()

--- a/weeks/week-10/solutions/1112405053/10235_EASY.py
+++ b/weeks/week-10/solutions/1112405053/10235_EASY.py
@@ -1,0 +1,49 @@
+import sys
+from collections import defaultdict
+
+MOD = 1000000007
+
+
+def count_cycles(grid, N, M):
+    dp = {(0, 0): 1}
+    for i in range(N):
+        for j in range(M):
+            nd = defaultdict(int)
+            for (mask, left), cnt in dp.items():
+                up = (mask >> j) & 1
+                l = left
+                avail = grid[i][j] == 1
+                right_ok = (j + 1 < M) and (grid[i][j + 1] == 1)
+                down_ok = (i + 1 < N) and (grid[i + 1][j] == 1)
+                if not avail:
+                    if l == 0 and up == 0:
+                        nd[(mask & ~(1 << j), 0)] = (nd[(mask & ~(1 << j), 0)] + cnt) % MOD
+                    continue
+                need = 2 - l - up
+                if need == 0:
+                    nd[(mask & ~(1 << j), 0)] = (nd[(mask & ~(1 << j), 0)] + cnt) % MOD
+                elif need == 2:
+                    if right_ok and down_ok:
+                        nd[((mask & ~(1 << j)) | (1 << j), 1)] = (nd[((mask & ~(1 << j)) | (1 << j), 1)] + cnt) % MOD
+                else:  # need == 1
+                    if right_ok:
+                        nd[(mask & ~(1 << j), 1)] = (nd[(mask & ~(1 << j), 1)] + cnt) % MOD
+                    if down_ok:
+                        nd[((mask & ~(1 << j)) | (1 << j), 0)] = (nd[((mask & ~(1 << j)) | (1 << j), 0)] + cnt) % MOD
+            dp = nd
+    return dp.get((0, 0), 0)
+
+
+def main():
+    it = iter(sys.stdin.read().split())
+    T = int(next(it, 0))
+    out = []
+    for tc in range(1, T + 1):
+        N = int(next(it)); M = int(next(it))
+        grid = [[int(next(it)) for _ in range(M)] for _ in range(N)]
+        out.append(f"Case {tc}: {count_cycles(grid, N, M)}")
+    sys.stdout.write("\n".join(out))
+
+
+if __name__ == '__main__':
+    main()

--- a/weeks/week-10/solutions/1112405053/10235_ME.py
+++ b/weeks/week-10/solutions/1112405053/10235_ME.py
@@ -1,0 +1,81 @@
+
+import sys
+
+MOD = 1000000007
+
+
+def count_cycle_covers(grid, N, M):
+	# grid: list of lists, 1 = available, 0 = socket (forbidden)
+	# DP state: mask (M bits) for down-edges coming into next row, left bit (0/1) for right-edge carry
+	from collections import defaultdict
+	dp = {(0, 0): 1}
+	for i in range(N):
+		for j in range(M):
+			ndp = defaultdict(int)
+			for (mask, left), cnt in dp.items():
+				u = (mask >> j) & 1
+				l = left
+				avail = grid[i][j] == 1
+				# determine availability of right and down neighbors
+				right_avail = (j + 1 < M) and (grid[i][j + 1] == 1)
+				down_avail = (i + 1 < N) and (grid[i + 1][j] == 1)
+				if not avail:
+					# must have degree 0 here
+					if l == 0 and u == 0:
+						new_mask = mask & ~(1 << j)
+						ndp[(new_mask, 0)] = (ndp[(new_mask, 0)] + cnt) % MOD
+					continue
+				need = 2 - l - u
+				if need < 0 or need > 2:
+					continue
+				# iterate possible (r,d) that sum to need
+				if need == 0:
+					r = 0; d = 0
+					new_mask = (mask & ~(1 << j))
+					ndp[(new_mask, 0)] = (ndp[(new_mask, 0)] + cnt) % MOD
+				elif need == 2:
+					# require both right and down
+					if right_avail and down_avail:
+						r = 1; d = 1
+						new_mask = (mask & ~(1 << j)) | (1 << j)
+						# new left will be r (1)
+						ndp[(new_mask, 1)] = (ndp[(new_mask, 1)] + cnt) % MOD
+				else:  # need == 1
+					# option r=1,d=0
+					if right_avail:
+						r = 1; d = 0
+						new_mask = (mask & ~(1 << j))
+						ndp[(new_mask, 1)] = (ndp[(new_mask, 1)] + cnt) % MOD
+					# option r=0,d=1
+					if down_avail:
+						r = 0; d = 1
+						new_mask = (mask & ~(1 << j)) | (1 << j)
+						ndp[(new_mask, 0)] = (ndp[(new_mask, 0)] + cnt) % MOD
+			dp = ndp
+		# end of row: left must be 0 for next row start; but states with left=1 are invalid because no cell to the left
+		# however our transition naturally only allows left=0 at row end because right_avail false for last column
+	# after all cells, accept only mask=0 and left=0
+	return dp.get((0, 0), 0)
+
+
+def main():
+	data = sys.stdin.read().strip().split()
+	if not data:
+		return
+	it = iter(data)
+	T = int(next(it))
+	out_lines = []
+	for tc in range(1, T + 1):
+		N = int(next(it)); M = int(next(it))
+		grid = [[0]*M for _ in range(N)]
+		for i in range(N):
+			for j in range(M):
+				grid[i][j] = int(next(it))
+		# grid uses 1 for available, 0 for socket
+		ans = count_cycle_covers(grid, N, M)
+		out_lines.append(f"Case {tc}: {ans}")
+	sys.stdout.write("\n".join(out_lines))
+
+
+if __name__ == '__main__':
+	main()

--- a/weeks/week-10/solutions/1112405053/10242_EASY.py
+++ b/weeks/week-10/solutions/1112405053/10242_EASY.py
@@ -1,0 +1,30 @@
+import sys
+
+
+def main():
+    it = iter(sys.stdin.read().split())
+    t = int(next(it, 0))
+    out = []
+    for _ in range(t):
+        n = int(next(it))
+        xs = [0]*n
+        ys = [0]*n
+        for i in range(n):
+            xs[i] = int(next(it)); ys[i] = int(next(it))
+        xs.sort(); ys.sort()
+        if n & 1:
+            xm = xs[n//2]; ym = ys[n//2]
+            s = sum(abs(x - xm) for x in xs) + sum(abs(y - ym) for y in ys)
+            cnt = 1
+        else:
+            xl = xs[n//2 - 1]; xh = xs[n//2]
+            yl = ys[n//2 - 1]; yh = ys[n//2]
+            s = sum(abs(x - xl) for x in xs) + sum(abs(y - yl) for y in ys)
+            cnt = (xh - xl + 1) * (yh - yl + 1)
+        out.append(f"{s} {cnt}")
+    sys.stdout.write("\n".join(out))
+
+
+if __name__ == '__main__':
+    main()
+

--- a/weeks/week-10/solutions/1112405053/10242_ME.py
+++ b/weeks/week-10/solutions/1112405053/10242_ME.py
@@ -1,0 +1,48 @@
+
+
+import sys
+
+
+def solve_all(data):
+	it = iter(data)
+	t = int(next(it))
+	out_lines = []
+	for _ in range(t):
+		n = int(next(it))
+		xs = [0]*n
+		ys = [0]*n
+		for i in range(n):
+			xs[i] = int(next(it))
+			ys[i] = int(next(it))
+		xs.sort()
+		ys.sort()
+		if n % 2 == 1:
+			xm = xs[n//2]
+			ym = ys[n//2]
+			sumx = sum(abs(x - xm) for x in xs)
+			sumy = sum(abs(y - ym) for y in ys)
+			cntx = 1
+			cnty = 1
+		else:
+			xl = xs[n//2 - 1]
+			xh = xs[n//2]
+			yl = ys[n//2 - 1]
+			yh = ys[n//2]
+			sumx = sum(abs(x - xl) for x in xs)
+			sumy = sum(abs(y - yl) for y in ys)
+			cntx = xh - xl + 1
+			cnty = yh - yl + 1
+		out_lines.append(f"{sumx + sumy} {cntx * cnty}")
+	return "\n".join(out_lines)
+
+
+def main():
+	data = sys.stdin.read().strip().split()
+	if not data:
+		return
+	print(solve_all(data))
+
+
+if __name__ == '__main__':
+	main()
+

--- a/weeks/week-10/solutions/1112405053/10252_EASY.py
+++ b/weeks/week-10/solutions/1112405053/10252_EASY.py
@@ -1,0 +1,29 @@
+import sys
+
+
+def main():
+    it = iter(sys.stdin.read().split())
+    t = int(next(it, 0))
+    out = []
+    for _ in range(t):
+        n = int(next(it))
+        xs = [0]*n
+        ys = [0]*n
+        for i in range(n):
+            xs[i] = int(next(it)); ys[i] = int(next(it))
+        xs.sort(); ys.sort()
+        if n & 1:
+            xm = xs[n//2]; ym = ys[n//2]
+            s = sum(abs(x - xm) for x in xs) + sum(abs(y - ym) for y in ys)
+            cnt = 1
+        else:
+            xl = xs[n//2 - 1]; xh = xs[n//2]
+            yl = ys[n//2 - 1]; yh = ys[n//2]
+            s = sum(abs(x - xl) for x in xs) + sum(abs(y - yl) for y in ys)
+            cnt = (xh - xl + 1) * (yh - yl + 1)
+        out.append(f"{s} {cnt}")
+    sys.stdout.write("\n".join(out))
+
+
+if __name__ == '__main__':
+    main()

--- a/weeks/week-10/solutions/1112405053/10252_ME.py
+++ b/weeks/week-10/solutions/1112405053/10252_ME.py
@@ -1,0 +1,46 @@
+
+import sys
+
+
+def solve_all(data):
+	it = iter(data)
+	t = int(next(it))
+	out_lines = []
+	for _ in range(t):
+		n = int(next(it))
+		xs = [0]*n
+		ys = [0]*n
+		for i in range(n):
+			xs[i] = int(next(it))
+			ys[i] = int(next(it))
+		xs.sort()
+		ys.sort()
+		if n % 2 == 1:
+			xm = xs[n//2]
+			ym = ys[n//2]
+			sumx = sum(abs(x - xm) for x in xs)
+			sumy = sum(abs(y - ym) for y in ys)
+			cntx = 1
+			cnty = 1
+		else:
+			xl = xs[n//2 - 1]
+			xh = xs[n//2]
+			yl = ys[n//2 - 1]
+			yh = ys[n//2]
+			sumx = sum(abs(x - xl) for x in xs)
+			sumy = sum(abs(y - yl) for y in ys)
+			cntx = xh - xl + 1
+			cnty = yh - yl + 1
+		out_lines.append(f"{sumx + sumy} {cntx * cnty}")
+	return "\n".join(out_lines)
+
+
+def main():
+	data = sys.stdin.read().strip().split()
+	if not data:
+		return
+	print(solve_all(data))
+
+
+if __name__ == '__main__':
+	main()

--- a/weeks/week-10/solutions/1112405053/10268_EASY.py
+++ b/weeks/week-10/solutions/1112405053/10268_EASY.py
@@ -1,0 +1,34 @@
+
+import sys
+
+
+def min_trials(k, n):
+	if n <= 1:
+		return 0
+	for m in range(1, 64):
+		s = 0
+		c = 1
+		for i in range(1, min(k, m) + 1):
+			c = c * (m - i + 1) // i
+			s += c
+			if s >= n:
+				return m
+	return None
+
+
+def main():
+	parts = sys.stdin.read().split()
+	it = iter(parts)
+	for a, b in zip(it, it):
+		k = int(a); n = int(b)
+		if k == 0:
+			break
+		r = min_trials(k, n)
+		if r is None:
+			print("More than 63 trials needed.")
+		else:
+			print(r)
+
+
+if __name__ == '__main__':
+	main()

--- a/weeks/week-10/solutions/1112405053/10268_ME.py
+++ b/weeks/week-10/solutions/1112405053/10268_ME.py
@@ -1,0 +1,39 @@
+
+import sys
+
+
+def min_trials(k: int, n: int) -> int | None:
+	if n <= 1:
+		return 0
+	for m in range(1, 64):
+		s = 0
+		term = 1
+		for i in range(1, min(k, m) + 1):
+			term = term * (m - i + 1) // i
+			s += term
+			if s >= n:
+				return m
+	return None
+
+
+def main():
+	data = sys.stdin.read().strip().split()
+	if not data:
+		return
+	it = iter(data)
+	out_lines = []
+	for a, b in zip(it, it):
+		k = int(a)
+		n = int(b)
+		if k == 0:
+			break
+		res = min_trials(k, n)
+		if res is None:
+			out_lines.append("More than 63 trials needed.")
+		else:
+			out_lines.append(str(res))
+	sys.stdout.write("\n".join(out_lines))
+
+
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
此 Pull Request 在 weeks/week-10/solutions/1112405053/ 新增了數個題目的解答檔案，並且每題同時提供「EASY」與「ME」（可能代表「我的版本」或「範例版本」）兩種版本。主要變更是新增多個完整、可獨立執行的 Python 腳本，實作所需演算法，並仔細處理輸入/輸出與效率需求。

最重要的變更如下：

排列與指派（Permutation / Assignment）問題：

在 10226_EASY.py 與 10226_ME.py 新增以 DFS 為基礎的解法，用來產生「具有禁止位置」限制的排列；兩者在程式結構與輸出處理上略有差異。[[1]](https://github.com/copilot/c/bf2ee8fe-5774-487c-8140-83e8d55bdcf9) [[2]](https://github.com/copilot/c/bf2ee8fe-5774-487c-8140-83e8d55bdcf9)
網格迴圈覆蓋（Grid Cycle Covers）的動態規劃：

在 10235_EASY.py 與 10235_ME.py 實作用於計算「含禁用格」網格中 cycle cover 數量的動態規劃解法。兩者皆使用 bitmask DP 與模運算，但實作細節不同。[[1]](https://github.com/copilot/c/bf2ee8fe-5774-487c-8140-83e8d55bdcf9) [[2]](https://github.com/copilot/c/bf2ee8fe-5774-487c-8140-83e8d55bdcf9)
2D 的中位數／距離計算：

在 10242_EASY.py 與 10242_ME.py 新增解法：找出最小的曼哈頓距離總和，以及最佳集合點（meeting points）的數量。[[1]](https://github.com/copilot/c/bf2ee8fe-5774-487c-8140-83e8d55bdcf9) [[2]](https://github.com/copilot/c/bf2ee8fe-5774-487c-8140-83e8d55bdcf9)
在 10252_EASY.py 與 10252_ME.py 也新增另一題結構相似的解法。[[1]](https://github.com/copilot/c/bf2ee8fe-5774-487c-8140-83e8d55bdcf9) [[2]](https://github.com/copilot/c/bf2ee8fe-5774-487c-8140-83e8d55bdcf9)
雞蛋掉落／最少測試次數（Egg Drop / Minimum Trials）問題：

在 10268_EASY.py 與 10268_ME.py 新增腳本，使用組合數邏輯計算經典 egg drop 問題的最少測試次數。[[1]](https://github.com/copilot/c/bf2ee8fe-5774-487c-8140-83e8d55bdcf9) [[2]](https://github.com/copilot/c/bf2ee8fe-5774-487c-8140-83e8d55bdcf9)