### PR TITLE
0521-1112405053-黃柏翰

### DIFF
--- a/weeks/week-13/solutions/1112405053/11005_AI.py
+++ b/weeks/week-13/solutions/1112405053/11005_AI.py
@@ -1,0 +1,43 @@
+import sys
+
+
+def main():
+	# 讀入所有數字，方便一次處理一筆測資
+	data = list(map(int, sys.stdin.read().split()))
+	if not data:
+		return
+	w = data[0]
+	n = data[1] if len(data) > 1 else 0
+	rest = data[2:]
+	if n <= 0:
+		print(0)
+		return
+	if len(rest) < n:
+		arr = rest
+	else:
+		arr = rest[:n]
+
+	# 依價格排序後，用雙指標盡量湊成一組兩件
+	arr.sort()
+	i = 0
+	j = len(arr) - 1
+	groups = 0
+	while i <= j:
+		if i == j:
+			groups += 1
+			break
+		if arr[i] + arr[j] <= w:
+			i += 1
+			j -= 1
+			groups += 1
+		else:
+			j -= 1
+			groups += 1
+
+	# 輸出最少需要的分組數
+	print(groups)
+
+
+if __name__ == '__main__':
+	main()
+

--- a/weeks/week-13/solutions/1112405053/11005_ME.py
+++ b/weeks/week-13/solutions/1112405053/11005_ME.py
@@ -1,0 +1,40 @@
+import sys
+
+
+def main():
+	data = list(map(int, sys.stdin.read().split()))
+	if not data:
+		return
+	w = data[0]
+	n = data[1] if len(data) > 1 else 0
+	rest = data[2:]
+	if n <= 0:
+		print(0)
+		return
+	if len(rest) < n:
+		arr = rest
+	else:
+		arr = rest[:n]
+
+	arr.sort()
+	i = 0
+	j = len(arr) - 1
+	groups = 0
+	while i <= j:
+		if i == j:
+			groups += 1
+			break
+		if arr[i] + arr[j] <= w:
+			i += 1
+			j -= 1
+			groups += 1
+		else:
+			j -= 1
+			groups += 1
+
+	print(groups)
+
+
+if __name__ == '__main__':
+	main()
+

--- a/weeks/week-13/solutions/1112405053/11063_AI.py
+++ b/weeks/week-13/solutions/1112405053/11063_AI.py
@@ -1,0 +1,43 @@
+import sys
+
+
+def process_dataset(n, values, out_lines):
+	# values: list of integers length = n*n*3
+	total_Y = 0.0
+	idx = 0
+	for _ in range(n * n):
+		R = values[idx]; G = values[idx+1]; B = values[idx+2]
+		idx += 3
+		X = 0.5149 * R + 0.3244 * G + 0.1607 * B
+		Y = 0.2654 * R + 0.6704 * G + 0.0642 * B
+		Z = 0.0248 * R + 0.1248 * G + 0.8504 * B
+		total_Y += Y
+		out_lines.append(f"{X:.4f} {Y:.4f} {Z:.4f}")
+	avgY = total_Y / (n * n) if n > 0 else 0.0
+	out_lines.append(f"The average of Y is {avgY:.4f}")
+
+
+def main():
+	data = sys.stdin.read().strip().split()
+	if not data:
+		return
+	nums = list(map(int, data))
+	res_lines = []
+	i = 0
+	L = len(nums)
+	while i < L:
+		n = nums[i]; i += 1
+		needed = n * n * 3
+		if i + needed > L:
+			# not enough data; stop
+			break
+		vals = nums[i:i+needed]
+		i += needed
+		process_dataset(n, vals, res_lines)
+
+	sys.stdout.write("\n".join(res_lines))
+
+
+if __name__ == '__main__':
+	main()
+

--- a/weeks/week-13/solutions/1112405053/11063_ME.py
+++ b/weeks/week-13/solutions/1112405053/11063_ME.py
@@ -1,0 +1,41 @@
+import sys
+
+
+def process_dataset(n, values, out_lines):
+	total_Y = 0.0
+	idx = 0
+	for _ in range(n * n):
+		R = values[idx]; G = values[idx+1]; B = values[idx+2]
+		idx += 3
+		X = 0.5149 * R + 0.3244 * G + 0.1607 * B
+		Y = 0.2654 * R + 0.6704 * G + 0.0642 * B
+		Z = 0.0248 * R + 0.1248 * G + 0.8504 * B
+		total_Y += Y
+		out_lines.append(f"{X:.4f} {Y:.4f} {Z:.4f}")
+	avgY = total_Y / (n * n) if n > 0 else 0.0
+	out_lines.append(f"The average of Y is {avgY:.4f}")
+
+
+def main():
+	data = sys.stdin.read().strip().split()
+	if not data:
+		return
+	nums = list(map(int, data))
+	res_lines = []
+	i = 0
+	L = len(nums)
+	while i < L:
+		n = nums[i]; i += 1
+		needed = n * n * 3
+		if i + needed > L:
+			break
+		vals = nums[i:i+needed]
+		i += needed
+		process_dataset(n, vals, res_lines)
+
+	sys.stdout.write("\n".join(res_lines))
+
+
+if __name__ == '__main__':
+	main()
+

--- a/weeks/week-13/solutions/1112405053/11150_AI.py
+++ b/weeks/week-13/solutions/1112405053/11150_AI.py
@@ -1,0 +1,70 @@
+import sys
+
+
+def compress_positions(length, stones):
+	positions = [0] + sorted(stones) + [length]
+	compressed = [0]
+	shift = 0
+	prev = 0
+
+	for pos in positions[1:]:
+		gap = pos - prev
+		if gap > 90:
+			shift += gap - 90
+		compressed.append(pos - shift)
+		prev = pos
+
+	return compressed
+
+
+def solve_case(length, s, t, stones):
+	positions = compress_positions(length, stones)
+	compressed_length = positions[-1]
+	stone_set = set(positions[1:-1])
+
+	limit = compressed_length + t
+	inf = 10**9
+	dp = [inf] * (limit + 1)
+	dp[0] = 0
+
+	for i in range(1, limit + 1):
+		best = inf
+		left = max(0, i - t)
+		right = i - s
+		if right >= left:
+			for j in range(left, right + 1):
+				if dp[j] < best:
+					best = dp[j]
+		if best < inf:
+			dp[i] = best + (1 if i in stone_set else 0)
+
+	return min(dp[compressed_length:limit + 1])
+
+
+def main():
+	data = list(map(int, sys.stdin.read().split()))
+	if not data:
+		return
+
+	out = []
+	idx = 0
+	n = len(data)
+	while idx < n:
+		length = data[idx]
+		idx += 1
+		if idx + 2 >= n:
+			break
+		s = data[idx]
+		t = data[idx + 1]
+		m = data[idx + 2]
+		idx += 3
+		stones = data[idx:idx + m]
+		idx += m
+		out.append(str(solve_case(length, s, t, stones)))
+
+	sys.stdout.write("\n".join(out))
+
+
+if __name__ == '__main__':
+	main()
+

--- a/weeks/week-13/solutions/1112405053/11150_ME.py
+++ b/weeks/week-13/solutions/1112405053/11150_ME.py
@@ -1,0 +1,70 @@
+import sys
+
+
+def compress_positions(length, stones):
+	positions = [0] + sorted(stones) + [length]
+	compressed = [0]
+	shift = 0
+	prev = 0
+
+	for pos in positions[1:]:
+		gap = pos - prev
+		if gap > 90:
+			shift += gap - 90
+		compressed.append(pos - shift)
+		prev = pos
+
+	return compressed
+
+
+def solve_case(length, s, t, stones):
+	positions = compress_positions(length, stones)
+	compressed_length = positions[-1]
+	stone_set = set(positions[1:-1])
+
+	limit = compressed_length + t
+	inf = 10**9
+	dp = [inf] * (limit + 1)
+	dp[0] = 0
+
+	for i in range(1, limit + 1):
+		best = inf
+		left = max(0, i - t)
+		right = i - s
+		if right >= left:
+			for j in range(left, right + 1):
+				if dp[j] < best:
+					best = dp[j]
+		if best < inf:
+			dp[i] = best + (1 if i in stone_set else 0)
+
+	return min(dp[compressed_length:limit + 1])
+
+
+def main():
+	data = list(map(int, sys.stdin.read().split()))
+	if not data:
+		return
+
+	out = []
+	idx = 0
+	n = len(data)
+	while idx < n:
+		length = data[idx]
+		idx += 1
+		if idx + 2 >= n:
+			break
+		s = data[idx]
+		t = data[idx + 1]
+		m = data[idx + 2]
+		idx += 3
+		stones = data[idx:idx + m]
+		idx += m
+		out.append(str(solve_case(length, s, t, stones)))
+
+	sys.stdout.write("\n".join(out))
+
+
+if __name__ == '__main__':
+	main()
+

--- a/weeks/week-13/solutions/1112405053/11321_AI.py
+++ b/weeks/week-13/solutions/1112405053/11321_AI.py
@@ -1,0 +1,113 @@
+import sys
+
+
+def solve_case(n, m, traps):
+	size = n * m
+	parent = [-1] * size
+	top_touch = bytearray(size)
+	bottom_touch = bytearray(size)
+	blocked = bytearray(size)
+
+	def find(x):
+		while parent[x] >= 0:
+			if parent[parent[x]] >= 0:
+				parent[x] = parent[parent[x]]
+			x = parent[x]
+		return x
+
+	def union(a, b):
+		a = find(a)
+		b = find(b)
+		if a == b:
+			return a
+		if parent[a] > parent[b]:
+			a, b = b, a
+		parent[a] += parent[b]
+		parent[b] = a
+		top_touch[a] |= top_touch[b]
+		bottom_touch[a] |= bottom_touch[b]
+		return a
+
+	out = []
+	for x, y in traps:
+		idx = x * m + y
+		roots = []
+		combined_top = x == 0
+		combined_bottom = x == n - 1
+
+		if x > 0:
+			up = idx - m
+			if blocked[up]:
+				r = find(up)
+				if r not in roots:
+					roots.append(r)
+					combined_top |= bool(top_touch[r])
+					combined_bottom |= bool(bottom_touch[r])
+		if x + 1 < n:
+			down = idx + m
+			if blocked[down]:
+				r = find(down)
+				if r not in roots:
+					roots.append(r)
+					combined_top |= bool(top_touch[r])
+					combined_bottom |= bool(bottom_touch[r])
+		if y > 0:
+			left = idx - 1
+			if blocked[left]:
+				r = find(left)
+				if r not in roots:
+					roots.append(r)
+					combined_top |= bool(top_touch[r])
+					combined_bottom |= bool(bottom_touch[r])
+		if y + 1 < m:
+			right = idx + 1
+			if blocked[right]:
+				r = find(right)
+				if r not in roots:
+					roots.append(r)
+					combined_top |= bool(top_touch[r])
+					combined_bottom |= bool(bottom_touch[r])
+
+		if combined_top and combined_bottom:
+			out.append('>_<')
+			continue
+
+		blocked[idx] = 1
+		parent[idx] = -1
+		top_touch[idx] = 1 if x == 0 else 0
+		bottom_touch[idx] = 1 if x == n - 1 else 0
+
+		root = idx
+		for r in roots:
+			root = union(root, r)
+
+		out.append('<(_ _)>')
+
+	return out
+
+
+def main():
+	data = list(map(int, sys.stdin.buffer.read().split()))
+	if not data:
+		return
+
+	idx = 0
+	outputs = []
+	total = len(data)
+	while idx + 2 < total:
+		n = data[idx]
+		m = data[idx + 1]
+		t = data[idx + 2]
+		idx += 3
+		if idx + 2 * t > total:
+			break
+		traps = [(data[idx + i], data[idx + i + 1]) for i in range(0, 2 * t, 2)]
+		idx += 2 * t
+		outputs.extend(solve_case(n, m, traps))
+
+	sys.stdout.write('\n'.join(outputs))
+
+
+if __name__ == '__main__':
+	main()
+

--- a/weeks/week-13/solutions/1112405053/11321_ME.py
+++ b/weeks/week-13/solutions/1112405053/11321_ME.py
@@ -1,0 +1,113 @@
+import sys
+
+
+def solve_case(n, m, traps):
+	size = n * m
+	parent = [-1] * size
+	top_touch = bytearray(size)
+	bottom_touch = bytearray(size)
+	blocked = bytearray(size)
+
+	def find(x):
+		while parent[x] >= 0:
+			if parent[parent[x]] >= 0:
+				parent[x] = parent[parent[x]]
+			x = parent[x]
+		return x
+
+	def union(a, b):
+		a = find(a)
+		b = find(b)
+		if a == b:
+			return a
+		if parent[a] > parent[b]:
+			a, b = b, a
+		parent[a] += parent[b]
+		parent[b] = a
+		top_touch[a] |= top_touch[b]
+		bottom_touch[a] |= bottom_touch[b]
+		return a
+
+	out = []
+	for x, y in traps:
+		idx = x * m + y
+		roots = []
+		combined_top = x == 0
+		combined_bottom = x == n - 1
+
+		if x > 0:
+			up = idx - m
+			if blocked[up]:
+				r = find(up)
+				if r not in roots:
+					roots.append(r)
+					combined_top |= bool(top_touch[r])
+					combined_bottom |= bool(bottom_touch[r])
+		if x + 1 < n:
+			down = idx + m
+			if blocked[down]:
+				r = find(down)
+				if r not in roots:
+					roots.append(r)
+					combined_top |= bool(top_touch[r])
+					combined_bottom |= bool(bottom_touch[r])
+		if y > 0:
+			left = idx - 1
+			if blocked[left]:
+				r = find(left)
+				if r not in roots:
+					roots.append(r)
+					combined_top |= bool(top_touch[r])
+					combined_bottom |= bool(bottom_touch[r])
+		if y + 1 < m:
+			right = idx + 1
+			if blocked[right]:
+				r = find(right)
+				if r not in roots:
+					roots.append(r)
+					combined_top |= bool(top_touch[r])
+					combined_bottom |= bool(bottom_touch[r])
+
+		if combined_top and combined_bottom:
+			out.append('>_<')
+			continue
+
+		blocked[idx] = 1
+		parent[idx] = -1
+		top_touch[idx] = 1 if x == 0 else 0
+		bottom_touch[idx] = 1 if x == n - 1 else 0
+
+		root = idx
+		for r in roots:
+			root = union(root, r)
+
+		out.append('<(_ _)>')
+
+	return out
+
+
+def main():
+	data = list(map(int, sys.stdin.buffer.read().split()))
+	if not data:
+		return
+
+	idx = 0
+	outputs = []
+	total = len(data)
+	while idx + 2 < total:
+		n = data[idx]
+		m = data[idx + 1]
+		t = data[idx + 2]
+		idx += 3
+		if idx + 2 * t > total:
+			break
+		traps = [(data[idx + i], data[idx + i + 1]) for i in range(0, 2 * t, 2)]
+		idx += 2 * t
+		outputs.extend(solve_case(n, m, traps))
+
+	sys.stdout.write('\n'.join(outputs))
+
+
+if __name__ == '__main__':
+	main()
+

--- a/weeks/week-13/solutions/1112405053/11332_AI.py
+++ b/weeks/week-13/solutions/1112405053/11332_AI.py
@@ -1,0 +1,251 @@
+import sys
+from functools import cmp_to_key
+from math import gcd
+
+
+class Node:
+	__slots__ = ('seg', 'prio', 'left', 'right', 'parent')
+
+	def __init__(self, seg):
+		self.seg = seg
+		self.prio = ((seg + 1) * 1103515245 + 12345) & 0x7fffffff
+		self.left = None
+		self.right = None
+		self.parent = None
+
+
+def normalize(x, y):
+	g = gcd(abs(x), abs(y))
+	return (x // g, y // g)
+
+
+def angle_cmp(a, b):
+	ax, ay = a
+	bx, by = b
+	ha = 0 if (ay > 0 or (ay == 0 and ax > 0)) else 1
+	hb = 0 if (by > 0 or (by == 0 and bx > 0)) else 1
+	if ha != hb:
+		return -1 if ha < hb else 1
+	cross = ax * by - ay * bx
+	if cross > 0:
+		return -1
+	if cross < 0:
+		return 1
+	return 0
+
+
+def ray_key(seg, vx, vy):
+	sx, sy, ex, ey = seg
+	dx = ex - sx
+	dy = ey - sy
+	num = sx * dy - sy * dx
+	den = vx * dy - vy * dx
+	if den < 0:
+		num = -num
+		den = -den
+	return num, den
+
+
+def closer(seg_a, seg_b, vx, vy):
+	a_num, a_den = ray_key(seg_a, vx, vy)
+	b_num, b_den = ray_key(seg_b, vx, vy)
+	return a_num * b_den < b_num * a_den
+
+
+def rotate_left(root, x):
+	y = x.right
+	x.right = y.left
+	if y.left is not None:
+		y.left.parent = x
+	y.parent = x.parent
+	if x.parent is None:
+		root = y
+	elif x.parent.left is x:
+		x.parent.left = y
+	else:
+		x.parent.right = y
+	y.left = x
+	x.parent = y
+	return root
+
+
+def rotate_right(root, x):
+	y = x.left
+	x.left = y.right
+	if y.right is not None:
+		y.right.parent = x
+	y.parent = x.parent
+	if x.parent is None:
+		root = y
+	elif x.parent.left is x:
+		x.parent.left = y
+	else:
+		x.parent.right = y
+	y.right = x
+	x.parent = y
+	return root
+
+
+def insert(root, node, vx, vy, segments):
+	node.left = node.right = node.parent = None
+	if root is None:
+		return node
+
+	cur = root
+	while True:
+		if closer(segments[node.seg], segments[cur.seg], vx, vy):
+			if cur.left is None:
+				cur.left = node
+				node.parent = cur
+				break
+			cur = cur.left
+		else:
+			if cur.right is None:
+				cur.right = node
+				node.parent = cur
+				break
+			cur = cur.right
+
+	while node.parent is not None and node.prio < node.parent.prio:
+		if node.parent.left is node:
+			root = rotate_right(root, node.parent)
+		else:
+			root = rotate_left(root, node.parent)
+	return root
+
+
+def remove(root, node):
+	while node.left is not None and node.right is not None:
+		if node.left.prio < node.right.prio:
+			root = rotate_right(root, node)
+		else:
+			root = rotate_left(root, node)
+
+	child = node.left if node.left is not None else node.right
+	if node.parent is None:
+		root = child
+		if child is not None:
+			child.parent = None
+	else:
+		if node.parent.left is node:
+			node.parent.left = child
+		else:
+			node.parent.right = child
+		if child is not None:
+			child.parent = node.parent
+
+	node.left = node.right = node.parent = None
+	return root
+
+
+def leftmost(root):
+	if root is None:
+		return None
+	while root.left is not None:
+		root = root.left
+	return root
+
+
+def sample_vector(a, b):
+	ax, ay = a
+	bx, by = b
+	cross = ax * by - ay * bx
+	if cross > 0:
+		return ax + bx, ay + by
+	if cross < 0:
+		return -(ax + bx), -(ay + by)
+	return -ay, ax
+
+
+def solve_case(n, raw_segments):
+	segments = []
+	dirs = []
+	for sx, sy, ex, ey in raw_segments:
+		p = normalize(sx, sy)
+		q = normalize(ex, ey)
+		dirs.append(p)
+		dirs.append(q)
+		segments.append((sx, sy, ex, ey, p, q))
+
+	unique_dirs = sorted(set(dirs), key=cmp_to_key(angle_cmp))
+	if len(unique_dirs) < 2:
+		return [0] * n
+
+	dir_index = {d: i for i, d in enumerate(unique_dirs)}
+	k = len(unique_dirs)
+
+	starts = [[] for _ in range(k)]
+	ends = [[] for _ in range(k)]
+	nodes = [Node(i) for i in range(n)]
+	visible = [0] * n
+	active = [False] * n
+
+	for i, (sx, sy, ex, ey, p, q) in enumerate(segments):
+		sp = dir_index[p]
+		ep = dir_index[q]
+		cross = p[0] * q[1] - p[1] * q[0]
+		if cross > 0:
+			start, end = sp, ep
+		elif cross < 0:
+			start, end = ep, sp
+		else:
+			# Zero angular width; ignored under the open-interval visibility model.
+			continue
+
+		starts[start].append(i)
+		ends[end].append(i)
+		if start > end:
+			active[i] = True
+
+	root = None
+	vx0, vy0 = sample_vector(unique_dirs[-1], unique_dirs[0])
+	for i in range(n):
+		if active[i]:
+			root = insert(root, nodes[i], vx0, vy0, segments)
+
+	for i in range(k):
+		for sid in ends[i]:
+			if active[sid]:
+				root = remove(root, nodes[sid])
+				active[sid] = False
+
+		vx, vy = sample_vector(unique_dirs[i], unique_dirs[(i + 1) % k])
+
+		for sid in starts[i]:
+			if not active[sid]:
+				root = insert(root, nodes[sid], vx, vy, segments)
+				active[sid] = True
+
+		front = leftmost(root)
+		if front is not None:
+			visible[front.seg] = 1
+
+	return visible
+
+
+def main():
+	data = list(map(int, sys.stdin.buffer.read().split()))
+	if not data:
+		return
+
+	out = []
+	idx = 0
+	total = len(data)
+	while idx < total:
+		n = data[idx]
+		idx += 1
+		if idx + 4 * n > total:
+			break
+		raw_segments = []
+		for _ in range(n):
+			raw_segments.append(tuple(data[idx:idx + 4]))
+			idx += 4
+		ans = solve_case(n, raw_segments)
+		out.append(' '.join(map(str, ans)))
+
+	sys.stdout.write('\n'.join(out))
+
+
+if __name__ == '__main__':
+	main()
+

--- a/weeks/week-13/solutions/1112405053/11332_ME.py
+++ b/weeks/week-13/solutions/1112405053/11332_ME.py
@@ -1,0 +1,250 @@
+import sys
+from functools import cmp_to_key
+from math import gcd
+
+
+class Node:
+	__slots__ = ('seg', 'prio', 'left', 'right', 'parent')
+
+	def __init__(self, seg):
+		self.seg = seg
+		self.prio = ((seg + 1) * 1103515245 + 12345) & 0x7fffffff
+		self.left = None
+		self.right = None
+		self.parent = None
+
+
+def normalize(x, y):
+	g = gcd(abs(x), abs(y))
+	return (x // g, y // g)
+
+
+def angle_cmp(a, b):
+	ax, ay = a
+	bx, by = b
+	ha = 0 if (ay > 0 or (ay == 0 and ax > 0)) else 1
+	hb = 0 if (by > 0 or (by == 0 and bx > 0)) else 1
+	if ha != hb:
+		return -1 if ha < hb else 1
+	cross = ax * by - ay * bx
+	if cross > 0:
+		return -1
+	if cross < 0:
+		return 1
+	return 0
+
+
+def ray_key(seg, vx, vy):
+	sx, sy, ex, ey = seg[:4]
+	dx = ex - sx
+	dy = ey - sy
+	num = sx * dy - sy * dx
+	den = vx * dy - vy * dx
+	if den < 0:
+		num = -num
+		den = -den
+	return num, den
+
+
+def closer(seg_a, seg_b, vx, vy):
+	a_num, a_den = ray_key(seg_a, vx, vy)
+	b_num, b_den = ray_key(seg_b, vx, vy)
+	return a_num * b_den < b_num * a_den
+
+
+def rotate_left(root, x):
+	y = x.right
+	x.right = y.left
+	if y.left is not None:
+		y.left.parent = x
+	y.parent = x.parent
+	if x.parent is None:
+		root = y
+	elif x.parent.left is x:
+		x.parent.left = y
+	else:
+		x.parent.right = y
+	y.left = x
+	x.parent = y
+	return root
+
+
+def rotate_right(root, x):
+	y = x.left
+	x.left = y.right
+	if y.right is not None:
+		y.right.parent = x
+	y.parent = x.parent
+	if x.parent is None:
+		root = y
+	elif x.parent.left is x:
+		x.parent.left = y
+	else:
+		x.parent.right = y
+	y.right = x
+	x.parent = y
+	return root
+
+
+def insert(root, node, vx, vy, segments):
+	node.left = node.right = node.parent = None
+	if root is None:
+		return node
+
+	cur = root
+	while True:
+		if closer(segments[node.seg], segments[cur.seg], vx, vy):
+			if cur.left is None:
+				cur.left = node
+				node.parent = cur
+				break
+			cur = cur.left
+		else:
+			if cur.right is None:
+				cur.right = node
+				node.parent = cur
+				break
+			cur = cur.right
+
+	while node.parent is not None and node.prio < node.parent.prio:
+		if node.parent.left is node:
+			root = rotate_right(root, node.parent)
+		else:
+			root = rotate_left(root, node.parent)
+	return root
+
+
+def remove(root, node):
+	while node.left is not None and node.right is not None:
+		if node.left.prio < node.right.prio:
+			root = rotate_right(root, node)
+		else:
+			root = rotate_left(root, node)
+
+	child = node.left if node.left is not None else node.right
+	if node.parent is None:
+		root = child
+		if child is not None:
+			child.parent = None
+	else:
+		if node.parent.left is node:
+			node.parent.left = child
+		else:
+			node.parent.right = child
+		if child is not None:
+			child.parent = node.parent
+
+	node.left = node.right = node.parent = None
+	return root
+
+
+def leftmost(root):
+	if root is None:
+		return None
+	while root.left is not None:
+		root = root.left
+	return root
+
+
+def sample_vector(a, b):
+	ax, ay = a
+	bx, by = b
+	cross = ax * by - ay * bx
+	if cross > 0:
+		return ax + bx, ay + by
+	if cross < 0:
+		return -(ax + bx), -(ay + by)
+	return -ay, ax
+
+
+def solve_case(n, raw_segments):
+	segments = []
+	dirs = []
+	for sx, sy, ex, ey in raw_segments:
+		p = normalize(sx, sy)
+		q = normalize(ex, ey)
+		dirs.append(p)
+		dirs.append(q)
+		segments.append((sx, sy, ex, ey, p, q))
+
+	unique_dirs = sorted(set(dirs), key=cmp_to_key(angle_cmp))
+	if len(unique_dirs) < 2:
+		return [0] * n
+
+	dir_index = {d: i for i, d in enumerate(unique_dirs)}
+	k = len(unique_dirs)
+
+	starts = [[] for _ in range(k)]
+	ends = [[] for _ in range(k)]
+	nodes = [Node(i) for i in range(n)]
+	visible = [0] * n
+	active = [False] * n
+
+	for i, (sx, sy, ex, ey, p, q) in enumerate(segments):
+		sp = dir_index[p]
+		ep = dir_index[q]
+		cross = p[0] * q[1] - p[1] * q[0]
+		if cross > 0:
+			start, end = sp, ep
+		elif cross < 0:
+			start, end = ep, sp
+		else:
+			continue
+
+		starts[start].append(i)
+		ends[end].append(i)
+		if start > end:
+			active[i] = True
+
+	root = None
+	vx0, vy0 = sample_vector(unique_dirs[-1], unique_dirs[0])
+	for i in range(n):
+		if active[i]:
+			root = insert(root, nodes[i], vx0, vy0, segments)
+
+	for i in range(k):
+		for sid in ends[i]:
+			if active[sid]:
+				root = remove(root, nodes[sid])
+				active[sid] = False
+
+		vx, vy = sample_vector(unique_dirs[i], unique_dirs[(i + 1) % k])
+
+		for sid in starts[i]:
+			if not active[sid]:
+				root = insert(root, nodes[sid], vx, vy, segments)
+				active[sid] = True
+
+		front = leftmost(root)
+		if front is not None:
+			visible[front.seg] = 1
+
+	return visible
+
+
+def main():
+	data = list(map(int, sys.stdin.buffer.read().split()))
+	if not data:
+		return
+
+	out = []
+	idx = 0
+	total = len(data)
+	while idx < total:
+		n = data[idx]
+		idx += 1
+		if idx + 4 * n > total:
+			break
+		raw_segments = []
+		for _ in range(n):
+			raw_segments.append(tuple(data[idx:idx + 4]))
+			idx += 4
+		ans = solve_case(n, raw_segments)
+		out.append(' '.join(map(str, ans)))
+
+	sys.stdout.write('\n'.join(out))
+
+
+if __name__ == '__main__':
+	main()
+


### PR DESCRIPTION
這個 Pull Request 在 weeks/week-13/solutions/1112405053/ 目錄下，新增了多個不同題目的 Python 解題腳本。每個題目均分別以 _AI.py 及 _ME.py 兩個版本實作，且結構類似：讀取輸入、處理題目邏輯並輸出結果。這些解答涵蓋了多種演算法技巧，包括貪婪配對、動態規劃、並查集（Union-Find）、及計算幾何等。

主要變更如下：

新增多道題目的解題實作：

新增 11005 題的解答，在 11005_AI.py 及 11005_ME.py 中透過貪婪雙指針方法，根據重量最小化分組數。[[1]](https://github.com/copilot/c/88c88d90-96ef-43db-8c39-fbeb713acc6a) [[2]](https://github.com/copilot/c/88c88d90-96ef-43db-8c39-fbeb713acc6a)
新增 11063 題的解答，在 11063_AI.py 及 11063_ME.py 處理一個 RGB 值網格，計算 XYZ 色彩空間，並輸出 Y 值平均。[[1]](https://github.com/copilot/c/88c88d90-96ef-43db-8c39-fbeb713acc6a) [[2]](https://github.com/copilot/c/88c88d90-96ef-43db-8c39-fbeb713acc6a)
新增 11150 題的解答，在 11150_AI.py 及 11150_ME.py 將石頭位置做壓縮並運用動態規劃，最小化踩到的石頭數。
新增 11321 題的解答，在 11321_AI.py 及 11321_ME.py 利用並查集結構追蹤陷阱設置過程中的連通性。
新增 11332 題的解答，在 11332_AI.py 及 11332_ME.py 透過計算幾何與 Treap 來判定線段可見性。[[1]](https://github.com/copilot/c/88c88d90-96ef-43db-8c39-fbeb713acc6a) [[2]](https://github.com/copilot/c/88c88d90-96ef-43db-8c39-fbeb713acc6a)