### PR TITLE
docs(week-15): link exam-sop-checklist-lite from week README

### DIFF
--- a/weeks/week-15/README.md
+++ b/weeks/week-15/README.md
@@ -4,6 +4,7 @@
 - 課堂範例：[`in_class/`](./in_class/) — 6/3 流程熱身、6/4 應用
 - 解題：本週無 `QUESTION-*.md`
 - 作業：依 6/3、6/4 課堂教案完成 PR；6/4 起需附 `AI_LOG.md`
+- 期末考 SOP：[`in_class/exam-sop-checklist-lite.md`](./in_class/exam-sop-checklist-lite.md) — 6/22 當天會發的精簡版檢查表
 
 ---
 


### PR DESCRIPTION
## 變更

在 `weeks/week-15/README.md` 開頭加上期末考精簡版檢查表的連結:

- [`in_class/exam-sop-checklist-lite.md`](weeks/week-15/in_class/exam-sop-checklist-lite.md) — 6/22 當天會發的精簡版 SOP 檢查表

接續已合併的 #992,讓學生從週首頁就能直接點到考試當天的檢查表。

🤖 Generated with [Claude Code](https://claude.com/claude-code)