### PR TITLE
docs(week-16): spell out implementation spec in starter READMEs

### DIFF
--- a/weeks/week-16/in_class/0610-starter/README.md
+++ b/weeks/week-16/in_class/0610-starter/README.md
@@ -10,8 +10,30 @@ cd weeks/week-16/solutions/<學號>/0610
 ## 檔案說明
 
 - `test_digit_root.py`：測試骨架，**請先補 ≥3 個 test case**（含 edge case 與例外案例）
-- `digit_root.py`：實作檔（尚未建立）。測試紅燈 commit 之後再建立。
+- `digit_root.py`：實作檔（尚未建立）。測試紅燈 commit 之後再建立，內容見下方規格。
 - 完成後追加 `AI_LOG.md`（範本見 [`week-15/in_class/ai-log-template.md`](../../../week-15/in_class/ai-log-template.md)）
+
+## `digit_root.py` 要寫什麼
+
+這個檔案只需要一個函式，規格如下：
+
+```python
+def digit_root(n: int) -> int:
+    ...
+```
+
+- **行為**：反覆把 `n` 的各位數字相加，直到結果只剩一位數，回傳那個一位數。
+  例：`199 → 1+9+9=19 → 1+9=10 → 1+0=1`，所以 `digit_root(199)` 回傳 `1`。
+- **輸入範圍**：正整數 `n`（1 ≤ n ≤ 2,000,000,000）。一位數直接回傳自己。
+- **例外**：`n < 1` 時必須 `raise ValueError("n must be >= 1")`——訊息文字要一字不差，測試會比對。
+- **不需要** `input()` / `print()`：這題只考核心函式，測試會直接 import 來呼叫。
+  檔名、函式名都不能改，否則 `test_digit_root.py` 的 import 會失敗。
+
+**完成的定義**：`python -m unittest` 從全紅變全綠，然後 commit（`feat:` 開頭）。
+怎麼寫、要不要用迴圈、問 AI 什麼——都是你的事，但 AI 給的程式碼你要能解釋，
+並把過程記進 `AI_LOG.md`。
+
+更多範例值見 [`../0610-timed-drill.md`](../0610-timed-drill.md) 的題目表格。
 
 ## 本日規則
 

--- a/weeks/week-16/in_class/0611-starter/README.md
+++ b/weeks/week-16/in_class/0611-starter/README.md
@@ -10,8 +10,30 @@ cd weeks/week-16/solutions/<學號>/0611
 ## 檔案說明
 
 - `test_carry_counter.py`：測試骨架，**請先補 ≥3 個 test case**（含 edge case 與例外案例）
-- `carry_counter.py`：實作檔（尚未建立）。測試紅燈 commit 之後再建立。
+- `carry_counter.py`：實作檔（尚未建立）。測試紅燈 commit 之後再建立，內容見下方規格。
 - 完成後追加 `AI_LOG.md`（範本見 [`week-15/in_class/ai-log-template.md`](../../../week-15/in_class/ai-log-template.md)）
+
+## `carry_counter.py` 要寫什麼
+
+這個檔案只需要一個函式，規格如下：
+
+```python
+def count_carries(a: int, b: int) -> int:
+    ...
+```
+
+- **行為**：回傳直式計算 `a + b` 時發生進位的次數。
+  例：`555 + 555`，個位 `5+5=10` 進位、十位 `5+5+1=11` 進位、百位 `5+5+1=11` 進位，
+  所以 `count_carries(555, 555)` 回傳 `3`。注意前一位的進位會影響下一位（`999 + 1` 是 3 次）。
+- **輸入範圍**：非負整數 `a`, `b`（0 ≤ a, b < 10,000,000,000）。
+- **例外**：`a` 或 `b` 為負數時必須 `raise ValueError("operands must be non-negative")`——訊息文字要一字不差，測試會比對。
+- **不需要** `input()` / `print()`：這題只考核心函式，測試會直接 import 來呼叫。
+  檔名、函式名都不能改，否則 `test_carry_counter.py` 的 import 會失敗。
+
+**完成的定義**：`python -m unittest` 從全紅變全綠，然後 commit（`feat:` 開頭）。
+AI 給的程式碼你要能解釋，並把過程記進 `AI_LOG.md`。
+
+更多範例值見 [`../0611-solo-drill.md`](../0611-solo-drill.md) 的題目表格。
 
 ## 本日規則
 


### PR DESCRIPTION
## Summary
- 在 0610 / 0611 starter README 補上「實作檔要寫什麼」一節：函式簽名、行為（含演算範例）、輸入範圍、ValueError 訊息需一字不差、不需要 input()/print()、完成的定義（全紅→全綠→ feat: commit）
- 只給規格、不給實作；「提示詞自己打」的規則不變

🤖 Generated with [Claude Code](https://claude.com/claude-code)