### PR TITLE
 0528-1114405055-解昱齊 

### DIFF
--- a/weeks/week-14/solutions/1114405055/R01-unittest-basics.py
+++ b/weeks/week-14/solutions/1114405055/R01-unittest-basics.py
@@ -1,0 +1,95 @@
+"""
+R01：unittest 基本用法（註解版參考程式）
+
+對應 Cookbook：
+- 14.1 測試 stdout 輸出
+- 14.2 在單元測試中給物件打補丁（mock.patch）
+- 14.3 在單元測試中測試例外情況
+
+執行：
+    python R01-unittest-basics.py
+"""
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
+
+
+# ---------- 被測函式 ----------
+def url_print(host, domain):
+    # 這個函式只會把組好的網址印到 stdout，沒有回傳值，
+    # 所以測試時要驗證「印出來的內容」而不是回傳值。
+    print(f"https://{host}.{domain}")
+
+
+def parse_int(s):
+    # 故意對空字串拋出明確訊息的 ValueError，方便示範 14.3 的例外測試。
+    if not s:
+        raise ValueError("空字串無法轉成整數")
+    return int(s)
+
+
+def fetch_user(api, user_id):
+    # api 是外部依賴（例如 HTTP client），測試時不會真的打 API，
+    # 而是用 mock 物件替換，這就是 14.2 的核心情境。
+    return api.get(f"/users/{user_id}")
+
+
+# ---------- 14.1 測試 stdout ----------
+class TestStdout(unittest.TestCase):
+    def test_url_print(self):
+        # io.StringIO() 建立一個「假的檔案物件」，存在記憶體中。
+        buf = io.StringIO()
+        # redirect_stdout 把 print() 原本要送到終端機的內容，
+        # 暫時導向到 buf，這樣才能在測試裡檢查印出的字串。
+        with redirect_stdout(buf):
+            url_print("www", "example.com")
+        # getvalue() 取出緩衝區內容；strip() 去掉結尾的換行符再比較。
+        self.assertEqual(buf.getvalue().strip(), "https://www.example.com")
+
+
+# ---------- 14.2 mock.patch ----------
+class TestPatch(unittest.TestCase):
+    def test_fetch_user_with_mock(self):
+        # MagicMock() 會自動產生任何屬性/方法呼叫，不會丟錯，
+        # 適合用來模擬一個我們還沒實作、或不想真的呼叫的物件。
+        fake_api = MagicMock()
+        # 設定 fake_api.get(...) 被呼叫時要回傳什麼。
+        fake_api.get.return_value = {"id": 1, "name": "Alice"}
+
+        result = fetch_user(fake_api, 1)
+
+        self.assertEqual(result["name"], "Alice")
+        # assert_called_once_with 同時驗證「只被呼叫一次」且「參數正確」，
+        # 比單純檢查回傳值更能保證程式邏輯正確。
+        fake_api.get.assert_called_once_with("/users/1")
+
+    @patch("builtins.print")
+    def test_url_print_via_patch(self, mock_print):
+        # @patch 裝飾器會在測試執行期間，把 builtins.print 換成 mock_print，
+        # 測試結束後自動還原，不會影響其他測試。
+        url_print("api", "example.com")
+        mock_print.assert_called_once_with("https://api.example.com")
+
+
+# ---------- 14.3 測試例外 ----------
+class TestExceptions(unittest.TestCase):
+    def test_raises(self):
+        # assertRaises 只檢查「有沒有丟出指定類型的例外」，
+        # with 區塊內的程式碼一旦丟出 ValueError 就視為通過。
+        with self.assertRaises(ValueError):
+            parse_int("")
+
+    def test_raises_with_message(self):
+        # assertRaisesRegex 多檢查一層：例外訊息是否符合正規表達式，
+        # 確保丟出的不只是「對的類型」，訊息內容也合理。
+        with self.assertRaisesRegex(ValueError, "空字串"):
+            parse_int("")
+
+    def test_normal_case(self):
+        # 正常路徑也要測，避免只顧著測例外而漏掉基本功能。
+        self.assertEqual(parse_int("42"), 42)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/weeks/week-14/solutions/1114405055/R02-exceptions-basic.py
+++ b/weeks/week-14/solutions/1114405055/R02-exceptions-basic.py
@@ -1,0 +1,83 @@
+"""
+R02：例外處理基本用法（註解版參考程式）
+
+對應 Cookbook：
+- 14.6 處理多個例外
+- 14.7 捕獲所有例外
+- 14.8 建立自定義例外
+
+執行：
+    python R02-exceptions-basic.py
+"""
+import traceback
+
+
+# ---------- 14.6 多個例外 ----------
+def parse_value(s):
+    """同一個 except 用 tuple 列出多種例外類別，共用同一段處理邏輯。"""
+    try:
+        return int(s)
+    except (ValueError, TypeError) as e:
+        # ValueError：字串內容無法轉成整數（例如 "abc"）。
+        # TypeError ：傳入的根本不是字串／數字（例如 None）。
+        # 兩種情況的處理方式相同，所以合併在同一個 except。
+        print(f"[14.6] 解析失敗 {type(e).__name__}: {e}")
+        return None
+
+
+# ---------- 14.7 捕獲所有例外 ----------
+def safe_run(func, *args):
+    """except Exception，而不是裸 except:（裸 except 連 KeyboardInterrupt、SystemExit 都會抓到，容易讓程式無法正常中斷）"""
+    try:
+        return func(*args)
+    except Exception as e:
+        print(f"[14.7] 發生例外 {type(e).__name__}: {e}")
+        # traceback.print_exc() 印出完整呼叫堆疊，方便除錯，
+        # 比只印 str(e) 能看到問題發生的確切位置。
+        traceback.print_exc()
+
+
+# ---------- 14.8 自定義例外 ----------
+class NetworkError(Exception):
+    """所有網路錯誤的基底類別；繼承 Exception 而不是 BaseException，
+    這樣外部程式碼可以用一個 except NetworkError 統一接住所有子類別。"""
+
+
+class HostnameError(NetworkError):
+    """找不到主機；不需要額外屬性，直接沿用 Exception 的訊息機制即可。"""
+
+
+class ConnectionTimeout(NetworkError):
+    """連線逾時，附帶 host / seconds 屬性，方便上層程式碼判斷是哪台主機、等了多久。"""
+    def __init__(self, host, seconds):
+        # 先呼叫 super().__init__ 設定好例外訊息，
+        # 再額外保存 host / seconds，讓 except 區塊可以直接讀取這些資訊。
+        super().__init__(f"連線 {host} 超過 {seconds} 秒")
+        self.host = host
+        self.seconds = seconds
+
+
+def connect(host, timeout):
+    if host == "":
+        raise HostnameError("主機名稱為空")
+    if timeout < 1:
+        raise ConnectionTimeout(host, timeout)
+    return f"connected to {host}"
+
+
+if __name__ == "__main__":
+    print("--- 14.6 ---")
+    parse_value("abc")
+    parse_value(None)
+
+    print("\n--- 14.7 ---")
+    safe_run(lambda: 1 / 0)
+
+    print("\n--- 14.8 ---")
+    for host, t in [("example.com", 5), ("", 5), ("slow.com", 0)]:
+        try:
+            print(connect(host, t))
+        except NetworkError as e:
+            # 因為 HostnameError / ConnectionTimeout 都繼承自 NetworkError，
+            # 這一個 except 就能同時接住兩種子類別的例外。
+            print(f"接到 {type(e).__name__}: {e}")

--- a/weeks/week-14/solutions/1114405055/R03-profile-basic.py
+++ b/weeks/week-14/solutions/1114405055/R03-profile-basic.py
@@ -1,0 +1,76 @@
+"""
+R03：效能測量基本用法（註解版參考程式）
+
+對應 Cookbook：
+- 14.13 給程式做效能測試（time / timeit / cProfile）
+
+執行：
+    python R03-profile-basic.py
+"""
+import cProfile
+import math
+import pstats
+import time
+import timeit
+from functools import wraps
+
+
+# ---------- 計時裝飾器（粗粒度） ----------
+def timed(func):
+    # @wraps(func) 保留原函式的 __name__ / __doc__ 等資訊，
+    # 否則被裝飾後 func.__name__ 會變成 "wrapper"，不利除錯與內省。
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        # time.perf_counter() 是高精度計時器，適合用來量「相對時間長度」，
+        # 不適合拿來當作絕對時間（牆上時鐘）使用。
+        t0 = time.perf_counter()
+        result = func(*args, **kwargs)
+        elapsed = time.perf_counter() - t0
+        print(f"[timed] {func.__name__}: {elapsed*1000:.2f} ms")
+        return result
+    return wrapper
+
+
+@timed
+def sum_of_squares(n):
+    return sum(i * i for i in range(n))
+
+
+# ---------- timeit：量微小片段 ----------
+def bench_timeit():
+    # timeit 會把同一段程式碼重複執行 number 次再取總時間，
+    # 這樣可以避免單次測量受系統雜訊（如排程、快取）影響太大。
+    n = 10_000
+    t1 = timeit.timeit("sum(i*i for i in range(n))",
+                       globals={"n": n}, number=1000)
+    t2 = timeit.timeit("sum(map(lambda i: i*i, range(n)))",
+                       globals={"n": n}, number=1000)
+    print(f"[timeit] genexp = {t1:.3f}s, map+lambda = {t2:.3f}s")
+
+
+# ---------- cProfile：找熱點 ----------
+def workload():
+    total = 0
+    for i in range(1, 5000):
+        total += math.sqrt(i) * math.sin(i)
+    return total
+
+
+def bench_cprofile():
+    # cProfile 會記錄程式執行期間，每個函式被呼叫的次數與耗時，
+    # 適合用來找出「整支程式裡真正拖慢效能的部分」，
+    # 而不是像 timeit 只能量一小段程式碼。
+    pr = cProfile.Profile()
+    pr.enable()
+    workload()
+    pr.disable()
+    print("[cProfile] 前 5 名：")
+    # sort_stats("cumulative") 依累積耗時排序（包含呼叫的子函式），
+    # print_stats(5) 只列出前 5 名，避免輸出過長。
+    pstats.Stats(pr).sort_stats("cumulative").print_stats(5)
+
+
+if __name__ == "__main__":
+    sum_of_squares(1_000_000)
+    bench_timeit()
+    bench_cprofile()

--- a/weeks/week-17/solutions/1114405055/0617/AI_LOG.md
+++ b/weeks/week-17/solutions/1114405055/0617/AI_LOG.md
@@ -1,0 +1,44 @@
+# AI_LOG — 0617
+
+## 我問 AI 什麼
+
+> TODO:把你自己打的提示詞逐字貼在這裡(本教案規則:提示詞自己打,不提供範例)。
+
+## AI 給了什麼
+
+> AI 先以「開發訪談助教」模式反問規格檢查表(五項:函式簽名/邊界/例外行為/edge case/驗收標準),
+> 確認檔滿後才給出 `timing.py`、`search.py`、`test_timing.py`、`test_search.py`、`benchmark.py`,
+> 並依紅燈→綠燈順序跑測試。
+
+## AI 反問我什麼 / 我怎麼回答
+
+> 逐項記下 AI 問的規格問題與你的決定。
+
+- **AI 問**:`repeat` 的邊界條件要驗證到什麼程度?
+  **我答**:只驗證型別與數值範圍——`repeat` 必須是 `int` 且 `>= 1`。`repeat="3"`(字串)與
+  `repeat=2.5`(float)都拒絕,因為 `range(repeat)` 需要 int,字串/小數傳進去語意不清楚;
+  `repeat=0` 或負數拒絕,因為至少要跑一次才能量到東西。
+
+- **AI 問**:被裝飾函式內部拋例外時,`timeit` 該怎麼處理?
+  **我答**:往外傳,不要吞掉。裝飾器的職責是測量,不是掩蓋錯誤;如果 `f` 本身有 bug 拋例外,
+  使用者應該看到原始例外。這次例外的那一輪**不計入** `records`,因為這一輪沒有正常結束、
+  沒有有效的 `elapsed` 值可以記錄——做法是把 `append` 放在 `elapsed = ...` 之後,例外發生時
+  那行根本不會執行,自然就不會被計入,不需要額外的 `try/except`。
+
+- **AI 問**:驗收標準(至少 3 個測試案例)要覆蓋哪些情境?
+  **我答**:
+  1. `test_returns_value_unchanged`——回傳值跟原函式直接呼叫一致。
+  2. `test_repeat_runs_n_times`——用 counter 驗證真的執行了 `repeat` 次。
+  3. `test_repeat_less_than_one_raises`(對應本檔的 `test_rejects_invalid_repeat`)——
+     `repeat=0`/`-1` 皆拋 `ValueError`。
+  4. `test_records_accumulates_across_calls`——呼叫兩次後 `records` 長度是 `2 * repeat`,
+     歷史會累積不會被清空。
+  5. `test_exception_propagates_and_not_recorded`——例外正確往外傳播,且 `records` 長度
+     沒有因此增加。
+
+## 我改了什麼
+
+> **這一行最重要,不能空白。** 寫清楚你做了什麼判斷或修改。
+>
+> TODO:這裡必須由你自己填——例如你檢查了哪段程式碼、發現了什麼問題、做了什麼決定
+> (留白或寫「沒改」依規則本項記 0 分)。

--- a/weeks/week-17/solutions/1114405055/0617/README.md
+++ b/weeks/week-17/solutions/1114405055/0617/README.md
@@ -1,0 +1,74 @@
+# 0617 Starter — timeit + 搜尋效能評估(預演)
+
+> 本日是 6/18 完整實驗室的**預演**:先把 `timeit` 做出來,再用它對搜尋做一次粗略評估。
+> 細節與課堂節奏見 [`../0617-search-eval.md`](../0617-search-eval.md)。
+
+## 使用方式
+
+```bash
+cp -r weeks/week-17/in_class/0617-starter weeks/week-17/solutions/<學號>/0617
+cd weeks/week-17/solutions/<學號>/0617
+```
+
+## 固定循環
+
+**Read spec → Dev for red(`test:` commit)→ Dev for green(`feat:` commit)→ push**。
+
+## 檔案說明
+
+- `test_timing.py`:任務一測試骨架,**先補齊測試、跑紅燈、commit,再寫 `timing.py`**
+- `search.py` 與它的測試**沒有骨架,自己從零寫**——鷹架到此淡出
+- `timing.py` 在**紅燈 commit 之後**才建立
+- 完成後追加 `AI_LOG.md`(範本見 [`../../week-15/in_class/ai-log-template.md`](../../week-15/in_class/ai-log-template.md))與 `TEST_LOG.md`
+
+## 規格速查
+
+### 任務一 `timing.py`(走完整 TDD)
+
+```python
+def timeit(func): ...        # 帶 repeat 參數,預設 3
+```
+
+- 回傳值不變;`functools.wraps` 保留 metadata
+- 每次呼叫實際跑 `repeat` 次,每次耗時 append 到 `f.records`
+- `f.last_elapsed` = 本次 `repeat` 的平均耗時(float 秒)
+- 裝飾器內不准 `print`
+- `repeat < 1` → `raise ValueError`(用 `raise`,**不准 `assert`**)
+
+### 任務二 `search.py`(輕量評估,不要求完整紅綠燈)
+
+```python
+def linear_search(data: list, target) -> int:   # 逐一比對,回傳 index,找不到回 -1
+def binary_search(data: list, target) -> int:   # 前提:data 已排序;回傳 index 或 -1
+```
+
+- 兩者**不可修改傳入的 data**
+- `binary_search` 收到未排序 data 的行為,自己定義並寫進 docstring
+- 用你的 `timeit` 量 linear vs binary,把評估(誰快/排序划不划算/直覺)寫進 `README.md`
+
+> 精確交叉點是明天 6/18 才用數據量出來的——今天先寫直覺。
+
+## 本日規則
+
+- [ ] 任務一先紅燈 commit(`test:`)再綠燈 commit(`feat:`)
+- [ ] **提示詞自己打**,逐字記入 `AI_LOG.md`;本目錄教案會讓 AI 自動進「開發訪談助教」模式,
+      它會先反問規格、填滿檢查表才給 code
+- [ ] `AI_LOG.md` 新增「AI 反問我什麼 / 我怎麼回答」欄,逐項記下問答
+- [ ] 任務二搜尋評估**不要求完整紅綠燈**,重點是跑出數據、做出判斷
+- [ ] 45 分鐘內 push 並開出合法 PR
+
+---
+
+## 搜尋效能評估(任務二實測結果)
+
+跑法:`python benchmark.py`(n = 200,000,target 設成最後一個元素,刻意製造 linear 的最壞情況,repeat=5)
+
+```
+linear_search  last_elapsed (avg of 5 runs) = 0.005520 s
+binary_search  last_elapsed (avg of 5 runs) = 0.000002 s
+linear / binary 倍數 = 2400.2x
+```
+
+1. **誰快?差多少?** `binary_search` 快非常多,在 n=200,000、最壞情況(找最後一個元素)下差了約 **2400 倍**。這符合 O(log n) vs O(n) 的理論預期:n 越大,線性搜尋要比對的次數線性增加,二分搜尋只增加 log₂(n)。
+2. **「排序 + binary」划不划算?(直覺)** 直覺上**不一定划算**——排序本身至少要 O(n log n),如果只搜尋一次,排序的成本可能就吃掉甚至超過搜尋省下的時間;但如果同一份 data 要被**重複搜尋很多次**(排序成本可以被分攤),那麼先排序再用 binary 應該整體更划算。
+3. 第 2 點的精確交叉點(要搜尋幾次才夠本)留給 6/18 用數據量出來,今天先記錄直覺。

--- a/weeks/week-17/solutions/1114405055/0617/TEST_LOG.md
+++ b/weeks/week-17/solutions/1114405055/0617/TEST_LOG.md
@@ -1,0 +1,59 @@
+# TEST_LOG — 0617
+
+## 任務一 `timing.py`(完整 TDD)
+
+### 紅燈(timing.py 尚未存在)
+
+```
+$ python -m unittest test_timing -v
+ImportError: Failed to import test module: test_timing
+ModuleNotFoundError: No module named 'timing'
+
+Ran 1 test in 0.000s
+
+FAILED (errors=1)
+```
+
+### 綠燈(寫完 timing.py 之後)
+
+```
+$ python -m unittest test_timing -v
+test_exception_propagates_and_not_recorded ... ok
+test_preserves_function_metadata ... ok
+test_records_accumulates_across_calls ... ok
+test_rejects_invalid_repeat ... ok
+test_repeat_runs_n_times ... ok
+test_returns_value_unchanged ... ok
+
+Ran 6 tests in 0.000s
+
+OK
+```
+
+## 任務二 `search.py`(輕量,不要求完整紅綠燈)
+
+```
+$ python -m unittest test_search -v
+test_does_not_mutate_input (TestBinarySearch) ... ok
+test_found_sorted (TestBinarySearch) ... ok
+test_not_found_sorted (TestBinarySearch) ... ok
+test_does_not_mutate_input (TestLinearSearch) ... ok
+test_found (TestLinearSearch) ... ok
+test_not_found (TestLinearSearch) ... ok
+
+Ran 6 tests in 0.000s
+
+OK
+```
+
+## 效能評估 `benchmark.py`
+
+```
+$ python benchmark.py
+n = 200000, target = 最後一個元素(最壞情況)
+linear_search  records = [0.0060637..., 0.0053461..., 0.0054251..., 0.0053499..., 0.0054170...]
+linear_search  last_elapsed (avg of 5 runs) = 0.005520 s
+binary_search  records = [4.3e-06, 2.4e-06, 1.7e-06, 1.5e-06, 1.6e-06]
+binary_search  last_elapsed (avg of 5 runs) = 0.000002 s
+linear / binary 倍數 = 2400.2x
+```

--- a/weeks/week-17/solutions/1114405055/0617/benchmark.py
+++ b/weeks/week-17/solutions/1114405055/0617/benchmark.py
@@ -1,0 +1,34 @@
+"""0617 任務二 — 用 timing.timeit 量 linear_search 與 binary_search
+
+跑法:python benchmark.py
+"""
+
+from timing import timeit
+from search import linear_search, binary_search
+
+N = 200_000
+data = list(range(N))
+target = N - 1  # 刻意挑最壞情況(linear 要找到最後一個)
+
+
+@timeit(repeat=5)
+def run_linear():
+    return linear_search(data, target)
+
+
+@timeit(repeat=5)
+def run_binary():
+    return binary_search(data, target)
+
+
+if __name__ == "__main__":
+    run_linear()
+    run_binary()
+
+    print(f"n = {N}, target = 最後一個元素(最壞情況)")
+    print(f"linear_search  records = {run_linear.records}")
+    print(f"linear_search  last_elapsed (avg of {len(run_linear.records)} runs) = {run_linear.last_elapsed:.6f} s")
+    print(f"binary_search  records = {run_binary.records}")
+    print(f"binary_search  last_elapsed (avg of {len(run_binary.records)} runs) = {run_binary.last_elapsed:.6f} s")
+    ratio = run_linear.last_elapsed / run_binary.last_elapsed
+    print(f"linear / binary 倍數 = {ratio:.1f}x")

--- a/weeks/week-17/solutions/1114405055/0617/search.py
+++ b/weeks/week-17/solutions/1114405055/0617/search.py
@@ -1,0 +1,31 @@
+"""0617 任務二 — 搜尋效能評估
+
+linear_search / binary_search 皆不修改傳入的 data。
+"""
+
+
+def linear_search(data: list, target) -> int:
+    """逐一比對 data,找到回傳 index,找不到回 -1。不要求 data 已排序。"""
+    for i, value in enumerate(data):
+        if value == target:
+            return i
+    return -1
+
+
+def binary_search(data: list, target) -> int:
+    """二分搜尋,前提:data 已排序(由小到大)。
+
+    若 data 實際上未排序,行為未定義——可能找不到本來存在的 target,
+    也可能誤判回傳 -1,因為二分搜尋每一步都假設左右兩側已分區。
+    本函式不會檢查、也不會排序傳入的 data(維持 O(log n),且不修改傳入物件)。
+    """
+    lo, hi = 0, len(data) - 1
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        if data[mid] == target:
+            return mid
+        elif data[mid] < target:
+            lo = mid + 1
+        else:
+            hi = mid - 1
+    return -1

--- a/weeks/week-17/solutions/1114405055/0617/test_search.py
+++ b/weeks/week-17/solutions/1114405055/0617/test_search.py
@@ -1,0 +1,35 @@
+"""0617 任務二 — search.py 輕量測試(不要求完整紅綠燈)"""
+
+import unittest
+
+from search import linear_search, binary_search
+
+
+class TestLinearSearch(unittest.TestCase):
+    def test_found(self):
+        self.assertEqual(linear_search([5, 3, 8, 1], 8), 2)
+
+    def test_not_found(self):
+        self.assertEqual(linear_search([5, 3, 8, 1], 99), -1)
+
+    def test_does_not_mutate_input(self):
+        data = [5, 3, 8, 1]
+        linear_search(data, 8)
+        self.assertEqual(data, [5, 3, 8, 1])
+
+
+class TestBinarySearch(unittest.TestCase):
+    def test_found_sorted(self):
+        self.assertEqual(binary_search([1, 3, 5, 8, 9], 8), 3)
+
+    def test_not_found_sorted(self):
+        self.assertEqual(binary_search([1, 3, 5, 8, 9], 99), -1)
+
+    def test_does_not_mutate_input(self):
+        data = [1, 3, 5, 8, 9]
+        binary_search(data, 8)
+        self.assertEqual(data, [1, 3, 5, 8, 9])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/weeks/week-17/solutions/1114405055/0617/test_timing.py
+++ b/weeks/week-17/solutions/1114405055/0617/test_timing.py
@@ -1,0 +1,86 @@
+"""0617 任務一 — timeit 裝飾器測試
+
+規格:timing.py 的 timeit 裝飾器必須
+  1. 不改變被裝飾函式的回傳值
+  2. 用 functools.wraps 保留 __name__ / __doc__
+  3. 每次呼叫實際跑 repeat 次(預設 3),把每次耗時 append 到 f.records,
+     f.last_elapsed = 本次 repeat 的平均耗時(float 秒)
+  4. 裝飾器內不准 print
+  5. repeat < 1 → raise ValueError(用 raise,不准 assert)
+  6. repeat 必須是 int(非 bool 以外的型別一律拒絕),否則 raise ValueError
+  7. 被裝飾函式內部拋例外時,例外原樣往外傳,且該輪不計入 records
+
+提醒:
+  - test_rejects_invalid_repeat 就是本日的安全測試(raise 而非 assert)。
+  - edge case:repeat=1、副作用函式是否被多算、例外是否被吞掉。
+"""
+
+import unittest
+
+from timing import timeit
+
+
+class TestTimeit(unittest.TestCase):
+    def test_returns_value_unchanged(self):
+        @timeit()
+        def add(a, b):
+            return a + b
+
+        self.assertEqual(add(2, 3), 5)
+
+    def test_preserves_function_metadata(self):
+        @timeit()
+        def add(a, b):
+            """加總兩個數"""
+            return a + b
+
+        self.assertEqual(add.__name__, "add")
+        self.assertEqual(add.__doc__, "加總兩個數")
+
+    def test_repeat_runs_n_times(self):
+        counter = {"calls": 0}
+
+        @timeit(repeat=5)
+        def side_effect():
+            counter["calls"] += 1
+            return counter["calls"]
+
+        side_effect()
+        self.assertEqual(counter["calls"], 5)
+
+    def test_records_accumulates_across_calls(self):
+        @timeit(repeat=3)
+        def noop():
+            return None
+
+        noop()
+        noop()
+        self.assertEqual(len(noop.records), 6)
+        self.assertTrue(all(isinstance(t, float) for t in noop.records))
+        self.assertIsInstance(noop.last_elapsed, float)
+
+    def test_rejects_invalid_repeat(self):
+        with self.assertRaises(ValueError):
+            timeit(repeat=0)
+
+        with self.assertRaises(ValueError):
+            timeit(repeat=-1)
+
+        with self.assertRaises(ValueError):
+            timeit(repeat="3")
+
+        with self.assertRaises(ValueError):
+            timeit(repeat=2.5)
+
+    def test_exception_propagates_and_not_recorded(self):
+        @timeit(repeat=3)
+        def boom():
+            raise RuntimeError("kaboom")
+
+        with self.assertRaises(RuntimeError):
+            boom()
+        self.assertEqual(len(boom.records), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/weeks/week-17/solutions/1114405055/0617/timing.py
+++ b/weeks/week-17/solutions/1114405055/0617/timing.py
@@ -1,0 +1,38 @@
+"""0617 任務一 — timeit 計時裝飾器
+
+timeit(repeat=3) 回傳一個裝飾器:
+  - 被裝飾函式的回傳值不變
+  - 每次呼叫實際跑 repeat 次,每次耗時(秒)append 到 wrapper.records
+  - wrapper.last_elapsed = 本次 repeat 的平均耗時
+  - 裝飾器內不 print
+  - repeat 必須是 int 且 >= 1,否則 raise ValueError(不用 assert)
+  - 被裝飾函式拋出例外時原樣往外傳,該輪不計入 records
+"""
+
+import functools
+import time
+
+
+def timeit(repeat=3):
+    if not isinstance(repeat, int) or isinstance(repeat, bool) or repeat < 1:
+        raise ValueError(f"repeat must be an int >= 1, got {repeat!r}")
+
+    def decorator(f):
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            elapsed_times = []
+            result = None
+            for _ in range(repeat):
+                start = time.perf_counter()
+                result = f(*args, **kwargs)
+                elapsed = time.perf_counter() - start
+                elapsed_times.append(elapsed)
+                wrapper.records.append(elapsed)
+            wrapper.last_elapsed = sum(elapsed_times) / len(elapsed_times)
+            return result
+
+        wrapper.records = []
+        wrapper.last_elapsed = None
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
新增三份對應《Python Cookbook》第 14 章主題的註解版參考程式，基於課堂 in_class 版本擴充，加上詳細中文註解說明每個技巧背後的「為什麼」：

R01-unittest-basics.py — unittest 基本用法
14.1 測試 stdout 輸出（redirect_stdout + StringIO）
14.2 用 mock.patch / MagicMock 隔離外部依賴
14.3 用 assertRaises / assertRaisesRegex 測試例外情況
R02-exceptions-basic.py — 例外處理基本用法
14.6 用 tuple 同時捕捉多種例外類型
14.7 用 except Exception（而非裸 except:）安全捕捉所有例外，並印出完整 traceback
14.8 自訂例外階層（NetworkError 基底類別 + HostnameError / ConnectionTimeout 子類別）
R03-profile-basic.py — 效能測量基本用法
用裝飾器搭配 time.perf_counter() 做粗粒度計時
用 timeit 比較兩種寫法（generator expression vs map+lambda）的微觀效能
用 cProfile + pstats 找出程式中的效能熱點
三份程式皆已實際執行驗證可正常運作（unittest 全數通過、例外處理與效能測量輸出符合預期）。